### PR TITLE
chore: convetional commits

### DIFF
--- a/.github/workflows/set-merge-message.yaml
+++ b/.github/workflows/set-merge-message.yaml
@@ -1,0 +1,36 @@
+name: Set Merge Commit Message from Branch
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  set-pr-title:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Extract conventional commit message from branch name
+        id: parse
+        run: |
+          BRANCH="${{ github.head_ref }}"
+          if [[ "$BRANCH" =~ ^([a-z]+)/(.+)$ ]]; then
+            TYPE="${BASH_REMATCH[1]}"
+            DESC="${BASH_REMATCH[2]//[-_]/ }"
+            echo "title=${TYPE}: ${DESC}" >> $GITHUB_OUTPUT
+          else
+            echo "Branch doesn't match expected format"
+            exit 1
+          fi
+
+      - name: Update PR title
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              title: "${{ steps.parse.outputs.title }}"
+            });


### PR DESCRIPTION
## Description

Automatically rename PRs to follow conventional commits names, for easier merging

## Motivation

There was an increasing mess in the git history

## Changes

- Create a workflow to rename branches, so merge commits are automatically named following convetions of conventional commits.

## Checklist

- [x] Code follows the style guidelines.
- [x] `nix flake check` passes.
- [x] Documentation is updated if needed.
- [x] Commit messages follow Conventional Commits.
- [x] You added yourself to [CONTRIBUTORS.md](./CONTRIBUTORS.md) (optional).
