### PR TITLE
fix: fix GNOME

### DIFF
--- a/desktop-enviroment/GNOME/default.nix
+++ b/desktop-enviroment/GNOME/default.nix
@@ -82,7 +82,7 @@
         ];
       };
 
-        home-manager.users.${username} = { pkgs, ... }: {
+      home-manager.users.${username} = {pkgs, ...}: {
         home.packages = with pkgs; [
           mission-center
           wmctrl
@@ -98,27 +98,27 @@
             enable = true;
 
             extensions = map (pkg: {package = pkg;}) (
-          with pkgs.gnomeExtensions; [
-            appindicator
-            blur-my-shell
-            clipboard-indicator
-            forge
-            just-perfection
-            caffeine
-            dash-to-dock
-            gsconnect
-            launch-new-instance
-            logo-menu
-            search-light
-            vitals
-          ]
+              with pkgs.gnomeExtensions; [
+                appindicator
+                blur-my-shell
+                clipboard-indicator
+                forge
+                just-perfection
+                caffeine
+                dash-to-dock
+                gsconnect
+                launch-new-instance
+                logo-menu
+                search-light
+                vitals
+              ]
             );
           };
         };
 
-          dconf = {
-            enable = true;
-            settings = {
+        dconf = {
+          enable = true;
+          settings = {
             "org/gnome/desktop/input-sources" = {
               current = 0;
               sources = [


### PR DESCRIPTION
- Add explicit dconf.enable = true in home-manager config
- Change home-manager parameter from '_:' to '{ pkgs, ... }:' for consistency
- Remove duplicate 'launch-new-instance' extension entry

Fixes #140

## Checklist

- [ ] Code follows the style guidelines.
- [ ] `nix flake check` passes.
- [ ] Documentation is updated if needed.
- [ ] Commit messages follow Conventional Commits.
- [ ] You added yourself to [CONTRIBUTORS.md](./CONTRIBUTORS.md) (optional).
