### PR TITLE
docs: Add NixOS logo attribution and license details

### DIFF
--- a/modules/desktop/README.md
+++ b/modules/desktop/README.md
@@ -26,6 +26,11 @@ Custom shell environment for Hyprland or Niri with the following features:
 - Enables GTK theming.
 - Enables Stylix for comprehensive theming.
 
+NixOS Logo designed by Tim Cuthbertson (@timbertson).
+
+The NixOS logo is licensed under the [Creative Commons Attribution 4.0
+International License](http://creativecommons.org/licenses/by/4.0/).
+
 ### Theme Configuration
 
 - Base16 Scheme: Gruvbox Dark.


### PR DESCRIPTION
Added attribution for NixOS logo and licensing information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with NixOS logo attribution and licensing information, including designer credit and Creative Commons BY 4.0 license reference in the theming configuration section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->