### PR TITLE
refactor: school notes in zed

### DIFF
--- a/modules/applications/programs.nix
+++ b/modules/applications/programs.nix
@@ -17,7 +17,6 @@ _: {
           users.${username} = {
             directories = [
               ".config/kdeconnect"
-              ".config/obsidian"
             ];
             files = [
               # User-level files to persist (relative to $HOME)
@@ -31,11 +30,6 @@ _: {
       };
 
       home-manager.users.${username} = _: {
-        programs = {
-          obsidian = {
-            enable = true;
-          };
-        };
       };
     };
   };

--- a/modules/development/IDE.nix
+++ b/modules/development/IDE.nix
@@ -10,9 +10,7 @@ _: {
         environment.persistence."/persist" = {
           users.${username} = {
             directories = [
-              ".config/VSCodium"
               ".config/zed"
-              ".vscode-oss"
             ];
             files = [
               ".wakatime.cfg"
@@ -23,31 +21,17 @@ _: {
 
       home-manager.users.${username} = {pkgs, ...}: {
         programs = {
-          vscodium = {
-            enable = true;
-            profiles.default = {
-              extensions = with pkgs.vscode-extensions; [
-                jnoortheen.nix-ide
-              ];
-              userSettings = {
-                "nix.enableLanguageServer" = true;
-                "nix.serverPath" = "nil";
-                "nix.formatterPath" = "alejandra";
-                "editor.formatOnSave" = true;
-                "workbench.editor.defaultBinaryEditor" = "hexEditor.treeview";
-              };
-            };
-          };
-
           micro = {
             enable = true;
           };
+
           zed-editor = {
             enable = true;
-            extensions = ["nix"];
+            extensions = ["nix" "markdown-snippets" "marksman"];
             extraPackages = with pkgs; [
               nil
               alejandra
+              marksman
             ];
 
             userSettings = {
@@ -62,6 +46,14 @@ _: {
               };
 
               languages = {
+                Markdown = {
+                  format_on_save = "on";
+                  formatter = "prettier";
+                  prettier = {
+                    allowed = true;
+                  };
+                };
+
                 Nix = {
                   language_servers = [
                     "nil"


### PR DESCRIPTION
## Motivation

I don't like obsidian anymore

## Changes

- Remove vscode and obsidian from the config
- Add markdown support to zed

## Fixes

- fixes #4 
- fixes #5

## Checklist

- [x] Code follows the style guidelines.
- [x] `nix flake check` passes.
- [x] Documentation is updated if needed.
- [x] Commit messages follow Conventional Commits.
- [x] You added yourself to [CONTRIBUTORS.md](./CONTRIBUTORS.md) (optional).
