### PR TITLE
feat/iroh config finish

### DIFF
--- a/.github/workflows/flake-build.yaml
+++ b/.github/workflows/flake-build.yaml
@@ -93,20 +93,20 @@ jobs:
         id: list
         run: |
           HOSTS=$(nix eval .#nixosConfigurations \
-            --apply 'n: builtins.map (name: { 
-            inherit name; 
-            type = "host"; 
-            system = n.${name}.config.nixpkgs.system; 
+            --apply 'n: builtins.map (name: {
+            inherit name;
+            type = "host";
+            system = n.${name}.config.nixpkgs.system;
             }) (builtins.attrNames n)' \
             --json)
 
           PKGS=$(nix eval .#packages \
-            --apply 'p: 
+            --apply 'p:
               builtins.concatLists (
-                builtins.map (system: 
-                  builtins.map (name: { 
-                    inherit name system; 
-                    type = "pkg"; 
+                builtins.map (system:
+                  builtins.map (name: {
+                    inherit name system;
+                    type = "pkg";
                   }) (builtins.attrNames p.${system})
                 ) (builtins.attrNames p)
               )' \
@@ -128,12 +128,16 @@ jobs:
           echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     needs: discover
     strategy:
       fail-fast: false
       matrix:
-        system: [x86_64-linux, aarch64-linux]
+        include:
+          - system: x86_64-linux
+            runner: ubuntu-latest
+          - system: aarch64-linux
+            runner: ubuntu-24.04-arm
     permissions:
       contents: read
       id-token: write
@@ -145,13 +149,6 @@ jobs:
       - uses: wimpysworld/nothing-but-nix@687c797a730352432950c707ab493fcc951818d7 # v10
         with:
           hatchet-protocol: cleave
-
-      - name: Enable aarch64 via QEMU binfmt
-        if: matrix.system == 'aarch64-linux'
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
-        with:
-          platforms: arm64
-          cache-image: true
 
       - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
         with:

--- a/.github/workflows/set-merge-message.yaml
+++ b/.github/workflows/set-merge-message.yaml
@@ -19,9 +19,9 @@ jobs:
         id: parse
         run: |
           BRANCH="${{ github.head_ref }}"
-          if [[ "$BRANCH" =~ ^([a-z]+)/(.+)$ ]]; then
+          if [[ "$BRANCH" =~ ^([a-z]+(\([^)]+\))?)/(.+)$ ]]; then
             TYPE="${BASH_REMATCH[1]}"
-            DESC="${BASH_REMATCH[2]//[-_]/ }"
+            DESC="${BASH_REMATCH[3]//[-_]/ }"
             echo "title=${TYPE}: ${DESC}" >> $GITHUB_OUTPUT
           else
             echo "Branch doesn't match expected format"

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ A comprehensive OS-as-a-code solution based on NixOS (Work in progress).
 
 ## Hosts Matrix
 
-| Hostname                               | Motherboard / Laptop Model | CPU         | GPU         | RAM  | Primary Purpose      |
-| -------------------------------------- | -------------------------- | ----------- | ----------- | ---- | -------------------- |
-| [armin](./hosts/armin/README.md)       | Framework 13               | Ryzen 7640U | Radeon 760M | 16GB | Desktop (GNOME)      |
-| [john](./hosts/john/README.md)         | N/A                        | N/A         | N/A         | N/A  | Installation ISO     |
-| [wall-e](./hosts/wall-e/README.md)     | N/A                        | N/A         | N/A         | N/A  | Installation ISO     |
-| [iroh](./hosts/iroh/README.md)         | Optiplex 3060 Micro        | i5 8500T 4c | UHD 630     | 24GB | Local Server in a VM |
-| [template](./hosts/template/README.md) | N/A                        | N/A         | N/A         | N/A  | Other                |
+| Hostname                               | Motherboard / Laptop Model | CPU         | GPU         | RAM  | Primary Purpose  |
+| -------------------------------------- | -------------------------- | ----------- | ----------- | ---- | ---------------- |
+| [armin](./hosts/armin/README.md)       | Framework 13               | Ryzen 7640U | Radeon 760M | 16GB | Desktop (GNOME)  |
+| [john](./hosts/john/README.md)         | N/A                        | N/A         | N/A         | N/A  | Installation ISO |
+| [wall-e](./hosts/wall-e/README.md)     | N/A                        | N/A         | N/A         | N/A  | Installation ISO |
+| [iroh](./hosts/iroh/README.md)         | Optiplex 3060 Micro        | i5 8500T    | UHD 630     | 32GB | Local Server     |
+| [template](./hosts/template/README.md) | N/A                        | N/A         | N/A         | N/A  | Other            |
 
 For more in depth explanation, visit [hosts](./docs/hosts.md).
 

--- a/docs/hosts.md
+++ b/docs/hosts.md
@@ -29,15 +29,14 @@ The name of this host is based on [Armin Arlert](https://attackontitan.fandom.co
 
 ## Iroh
 
-This is the main services VM on my Proxmox server.
-I run my services with [Nix-Podman-Stacks](https://github.com/Tarow/nix-podman-stacks).
+This is my home server
 
 Specs:
 
-- i5 8500T 4c
+- i5 8500T
 - UHD 630
-- 24GB of RAM 2666MT/s DDR4
-- 100GB NVMe SSD
+- 32GB of RAM 2666MT/s DDR4
+- 256GB NVMe SSD
 - 512GB SATA SSD
 - 14TB HDD in a SATA to USB enclosure
 

--- a/hosts/armin/default.nix
+++ b/hosts/armin/default.nix
@@ -37,7 +37,7 @@ in {
       self.nixosModules.input
       self.nixosModules.locale
       self.nixosModules.moonlight
-      self.nixosModules.nas-client
+      self.nixosModules.nasClient
       self.nixosModules.networking-desktop
       self.nixosModules.nix
       self.nixosModules.opencode

--- a/hosts/armin/default.nix
+++ b/hosts/armin/default.nix
@@ -37,6 +37,7 @@ in {
       self.nixosModules.input
       self.nixosModules.locale
       self.nixosModules.moonlight
+      self.nixosModules.nas-client
       self.nixosModules.networking-desktop
       self.nixosModules.nix
       self.nixosModules.opencode

--- a/hosts/armin/hardware.nix
+++ b/hosts/armin/hardware.nix
@@ -49,7 +49,7 @@
     };
   };
 
-  system.stateVersion = "26.05";
+  system.stateVersion = "26.11";
 
   imports = [
     inputs.nixos-hardware.nixosModules.framework-13-7040-amd
@@ -58,6 +58,6 @@
   ];
 
   home-manager.users.${username} = _: {
-    home.stateVersion = "26.05";
+    home.stateVersion = "26.11";
   };
 }

--- a/hosts/iroh/default.nix
+++ b/hosts/iroh/default.nix
@@ -31,6 +31,7 @@ in {
       self.nixosModules.home-manager
       self.nixosModules.home-server-iroh
       self.nixosModules.locale
+      self.nixosModules.nas-server
       self.nixosModules.networking-server
       self.nixosModules.nix
       self.nixosModules.secrets

--- a/hosts/iroh/default.nix
+++ b/hosts/iroh/default.nix
@@ -31,7 +31,7 @@ in {
       self.nixosModules.home-manager
       self.nixosModules.home-server-iroh
       self.nixosModules.locale
-      self.nixosModules.nas-server
+      self.nixosModules.nasServer
       self.nixosModules.networking-server
       self.nixosModules.nix
       self.nixosModules.secrets

--- a/hosts/iroh/disko.nix
+++ b/hosts/iroh/disko.nix
@@ -106,7 +106,7 @@ _: {
 
       hdd = {
         type = "disk";
-        device = "/dev/sdc";
+        device = "/dev/disk/by-id/ata-WDC_WUH721414ALN600_9JJ0V75T";
         content = {
           type = "gpt";
           partitions = {

--- a/hosts/iroh/disko.nix
+++ b/hosts/iroh/disko.nix
@@ -3,7 +3,7 @@ _: {
     disk = {
       root = {
         type = "disk";
-        device = "/dev/sda";
+        device = "/dev/disk/by-id/nvme-PM991a_NVMe_Samsung_256GB__S660NX1T729293";
         content = {
           type = "gpt";
           partitions = {
@@ -84,7 +84,7 @@ _: {
 
       ssd = {
         type = "disk";
-        device = "/dev/sdb";
+        device = "/dev/disk/by-id/ata-SSDPR-CX400-512-G2_4S0218458";
         content = {
           type = "gpt";
           partitions = {

--- a/hosts/iroh/facter.json
+++ b/hosts/iroh/facter.json
@@ -1,0 +1,3311 @@
+{
+  "version": 1,
+  "system": "x86_64-linux",
+  "virtualisation": "none",
+  "uefi": {
+    "supported": true,
+    "platform_size": 64
+  },
+  "hardware": {
+    "bios": {
+      "apm_info": {
+        "supported": false,
+        "enabled": false,
+        "version": 0,
+        "sub_version": 0,
+        "bios_flags": 0
+      },
+      "vbe_info": {
+        "version": 0,
+        "video_memory": 0
+      },
+      "pnp": false,
+      "pnp_id": 0,
+      "lba_support": false,
+      "low_memory_size": 0,
+      "smbios_version": 769
+    },
+    "bridge": [
+      {
+        "index": 11,
+        "attached_to": 0,
+        "class_list": [
+          "pci",
+          "bridge"
+        ],
+        "bus_type": {
+          "hex": "0004",
+          "name": "PCI",
+          "value": 4
+        },
+        "slot": {
+          "bus": 0,
+          "number": 28
+        },
+        "base_class": {
+          "hex": "0006",
+          "name": "Bridge",
+          "value": 6
+        },
+        "sub_class": {
+          "hex": "0004",
+          "name": "PCI bridge",
+          "value": 4
+        },
+        "pci_interface": {
+          "hex": "0000",
+          "name": "Normal decode",
+          "value": 0
+        },
+        "vendor": {
+          "hex": "8086",
+          "name": "Intel Corporation",
+          "value": 32902
+        },
+        "sub_vendor": {
+          "hex": "1028",
+          "value": 4136
+        },
+        "device": {
+          "hex": "a33c",
+          "value": 41788
+        },
+        "sub_device": {
+          "hex": "085c",
+          "value": 2140
+        },
+        "revision": {
+          "hex": "00f0",
+          "value": 240
+        },
+        "model": "Intel PCI bridge",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1c.0",
+        "sysfs_bus_id": "0000:00:1c.0",
+        "detail": {
+          "function": 0,
+          "command": 1287,
+          "header_type": 1,
+          "secondary_bus": 1,
+          "prog_if": 0
+        },
+        "driver": "pcieport",
+        "driver_module": "pcieportdrv",
+        "drivers": [
+          "pcieport"
+        ],
+        "driver_modules": [
+          "pcieportdrv"
+        ],
+        "module_alias": "pci:v00008086d0000A33Csv00001028sd0000085Cbc06sc04i00"
+      },
+      {
+        "index": 13,
+        "attached_to": 0,
+        "class_list": [
+          "pci",
+          "bridge"
+        ],
+        "bus_type": {
+          "hex": "0004",
+          "name": "PCI",
+          "value": 4
+        },
+        "slot": {
+          "bus": 0,
+          "number": 31
+        },
+        "base_class": {
+          "hex": "0006",
+          "name": "Bridge",
+          "value": 6
+        },
+        "sub_class": {
+          "hex": "0001",
+          "name": "ISA bridge",
+          "value": 1
+        },
+        "vendor": {
+          "hex": "8086",
+          "name": "Intel Corporation",
+          "value": 32902
+        },
+        "sub_vendor": {
+          "hex": "1028",
+          "value": 4136
+        },
+        "device": {
+          "hex": "a304",
+          "value": 41732
+        },
+        "sub_device": {
+          "hex": "085c",
+          "value": 2140
+        },
+        "revision": {
+          "hex": "0010",
+          "value": 16
+        },
+        "model": "Intel ISA bridge",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1f.0",
+        "sysfs_bus_id": "0000:00:1f.0",
+        "detail": {
+          "function": 0,
+          "command": 263,
+          "header_type": 0,
+          "secondary_bus": 0,
+          "prog_if": 0
+        },
+        "module_alias": "pci:v00008086d0000A304sv00001028sd0000085Cbc06sc01i00",
+        "label": "Onboard - Other"
+      },
+      {
+        "index": 19,
+        "attached_to": 0,
+        "class_list": [
+          "pci",
+          "bridge"
+        ],
+        "bus_type": {
+          "hex": "0004",
+          "name": "PCI",
+          "value": 4
+        },
+        "slot": {
+          "bus": 0,
+          "number": 0
+        },
+        "base_class": {
+          "hex": "0006",
+          "name": "Bridge",
+          "value": 6
+        },
+        "sub_class": {
+          "hex": "0000",
+          "name": "Host bridge",
+          "value": 0
+        },
+        "vendor": {
+          "hex": "8086",
+          "name": "Intel Corporation",
+          "value": 32902
+        },
+        "sub_vendor": {
+          "hex": "1028",
+          "value": 4136
+        },
+        "device": {
+          "hex": "3ec2",
+          "value": 16066
+        },
+        "sub_device": {
+          "hex": "085c",
+          "value": 2140
+        },
+        "revision": {
+          "hex": "0007",
+          "value": 7
+        },
+        "model": "Intel Host bridge",
+        "sysfs_id": "/devices/pci0000:00/0000:00:00.0",
+        "sysfs_bus_id": "0000:00:00.0",
+        "detail": {
+          "function": 0,
+          "command": 262,
+          "header_type": 0,
+          "secondary_bus": 0,
+          "prog_if": 0
+        },
+        "driver": "skl_uncore",
+        "driver_module": "intel_uncore",
+        "drivers": [
+          "skl_uncore"
+        ],
+        "driver_modules": [
+          "intel_uncore"
+        ],
+        "module_alias": "pci:v00008086d00003EC2sv00001028sd0000085Cbc06sc00i00",
+        "label": "Onboard - Other"
+      },
+      {
+        "index": 21,
+        "attached_to": 0,
+        "class_list": [
+          "pci",
+          "bridge"
+        ],
+        "bus_type": {
+          "hex": "0004",
+          "name": "PCI",
+          "value": 4
+        },
+        "slot": {
+          "bus": 0,
+          "number": 29
+        },
+        "base_class": {
+          "hex": "0006",
+          "name": "Bridge",
+          "value": 6
+        },
+        "sub_class": {
+          "hex": "0004",
+          "name": "PCI bridge",
+          "value": 4
+        },
+        "pci_interface": {
+          "hex": "0000",
+          "name": "Normal decode",
+          "value": 0
+        },
+        "vendor": {
+          "hex": "8086",
+          "name": "Intel Corporation",
+          "value": 32902
+        },
+        "sub_vendor": {
+          "hex": "1028",
+          "value": 4136
+        },
+        "device": {
+          "hex": "a330",
+          "value": 41776
+        },
+        "sub_device": {
+          "hex": "085c",
+          "value": 2140
+        },
+        "revision": {
+          "hex": "00f0",
+          "value": 240
+        },
+        "model": "Intel PCI bridge",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1d.0",
+        "sysfs_bus_id": "0000:00:1d.0",
+        "detail": {
+          "function": 0,
+          "command": 1287,
+          "header_type": 1,
+          "secondary_bus": 2,
+          "prog_if": 0
+        },
+        "driver": "pcieport",
+        "driver_module": "pcieportdrv",
+        "drivers": [
+          "pcieport"
+        ],
+        "driver_modules": [
+          "pcieportdrv"
+        ],
+        "module_alias": "pci:v00008086d0000A330sv00001028sd0000085Cbc06sc04i00"
+      }
+    ],
+    "cpu": [
+      {
+        "architecture": "x86_64",
+        "vendor_name": "GenuineIntel",
+        "model_name": "Intel(R) Core(TM) i5-8500T CPU @ 2.10GHz",
+        "family": 6,
+        "model": 158,
+        "stepping": 10,
+        "features": [
+          "fpu",
+          "vme",
+          "de",
+          "pse",
+          "tsc",
+          "msr",
+          "pae",
+          "mce",
+          "cx8",
+          "apic",
+          "sep",
+          "mtrr",
+          "pge",
+          "mca",
+          "cmov",
+          "pat",
+          "pse36",
+          "clflush",
+          "dts",
+          "acpi",
+          "mmx",
+          "fxsr",
+          "sse",
+          "sse2",
+          "ss",
+          "ht",
+          "tm",
+          "pbe",
+          "syscall",
+          "nx",
+          "pdpe1gb",
+          "rdtscp",
+          "lm",
+          "constant_tsc",
+          "art",
+          "arch_perfmon",
+          "pebs",
+          "bts",
+          "rep_good",
+          "nopl",
+          "xtopology",
+          "nonstop_tsc",
+          "cpuid",
+          "aperfmperf",
+          "pni",
+          "pclmulqdq",
+          "dtes64",
+          "monitor",
+          "ds_cpl",
+          "vmx",
+          "smx",
+          "est",
+          "tm2",
+          "ssse3",
+          "sdbg",
+          "fma",
+          "cx16",
+          "xtpr",
+          "pdcm",
+          "pcid",
+          "sse4_1",
+          "sse4_2",
+          "x2apic",
+          "movbe",
+          "popcnt",
+          "tsc_deadline_timer",
+          "aes",
+          "xsave",
+          "avx",
+          "f16c",
+          "rdrand",
+          "lahf_lm",
+          "abm",
+          "3dnowprefetch",
+          "cpuid_fault",
+          "epb",
+          "pti",
+          "ssbd",
+          "ibrs",
+          "ibpb",
+          "stibp",
+          "tpr_shadow",
+          "flexpriority",
+          "ept",
+          "vpid",
+          "ept_ad",
+          "fsgsbase",
+          "tsc_adjust",
+          "bmi1",
+          "hle",
+          "avx2",
+          "smep",
+          "bmi2",
+          "erms",
+          "invpcid",
+          "rtm",
+          "mpx",
+          "rdseed",
+          "adx",
+          "smap",
+          "clflushopt",
+          "intel_pt",
+          "xsaveopt",
+          "xsavec",
+          "xgetbv1",
+          "xsaves",
+          "dtherm",
+          "ida",
+          "arat",
+          "pln",
+          "pts",
+          "hwp",
+          "hwp_notify",
+          "hwp_act_window",
+          "hwp_epp",
+          "vnmi",
+          "md_clear",
+          "flush_l1d"
+        ],
+        "bugs": [
+          "cpu_meltdown",
+          "spectre_v1",
+          "spectre_v2",
+          "spec_store_bypass",
+          "l1tf",
+          "mds",
+          "swapgs",
+          "taa",
+          "itlb_multihit",
+          "srbds",
+          "mmio_stale_data",
+          "retbleed",
+          "gds",
+          "spectre_v2_user",
+          "old_microcode",
+          "vmscape"
+        ],
+        "power_management": [
+          ""
+        ],
+        "bogo": 4199,
+        "cache": 9216,
+        "units": 16,
+        "page_size": 4096,
+        "physical_id": 0,
+        "siblings": 6,
+        "cores": 6,
+        "fpu": false,
+        "fpu_exception": false,
+        "cpuid_level": 22,
+        "write_protect": false,
+        "tlb_size": 29142,
+        "clflush_size": 64,
+        "cache_alignment": 64,
+        "address_sizes": {
+          "physical": "0x27",
+          "virtual": "0x30"
+        }
+      }
+    ],
+    "disk": [
+      {
+        "index": 28,
+        "attached_to": 14,
+        "class_list": [
+          "disk",
+          "block_device",
+          "nvme"
+        ],
+        "bus_type": {
+          "hex": "0096",
+          "name": "NVME",
+          "value": 150
+        },
+        "slot": {
+          "bus": 0,
+          "number": 0
+        },
+        "base_class": {
+          "hex": "0106",
+          "name": "Mass Storage Device",
+          "value": 262
+        },
+        "sub_class": {
+          "hex": "0000",
+          "name": "Disk",
+          "value": 0
+        },
+        "vendor": {
+          "hex": "144d",
+          "value": 5197
+        },
+        "sub_vendor": {
+          "hex": "144d",
+          "value": 5197
+        },
+        "device": {
+          "hex": "a809",
+          "name": "PM991a NVMe Samsung 256GB",
+          "value": 43017
+        },
+        "sub_device": {
+          "hex": "a801",
+          "value": 43009
+        },
+        "serial": "S660NX1T729293",
+        "model": "PM991a NVMe Samsung 256GB",
+        "sysfs_id": "/class/block/nvme0n1",
+        "sysfs_bus_id": "nvme0",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:1d.0/0000:02:00.0/nvme/nvme0",
+        "unix_device_names": [
+          "/dev/disk/by-id/nvme-PM991a_NVMe_Samsung_256GB__S660NX1T729293",
+          "/dev/disk/by-id/nvme-PM991a_NVMe_Samsung_256GB_______S660NX1T729293",
+          "/dev/disk/by-id/nvme-PM991a_NVMe_Samsung_256GB_______S660NX1T729293_1",
+          "/dev/disk/by-id/nvme-eui.36363031547292930025385800000001",
+          "/dev/disk/by-path/pci-0000:02:00.0-nvme-1",
+          "/dev/nvme0n1"
+        ],
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 244198,
+            "heads": 64,
+            "sectors": 32,
+            "size": "0x0",
+            "geo_type": "logical"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 500118192,
+            "value_2": 512
+          }
+        ],
+        "driver": "nvme",
+        "driver_module": "nvme",
+        "drivers": [
+          "nvme"
+        ],
+        "driver_modules": [
+          "nvme"
+        ]
+      },
+      {
+        "index": 29,
+        "attached_to": 24,
+        "class_list": [
+          "disk",
+          "usb",
+          "scsi",
+          "block_device"
+        ],
+        "bus_type": {
+          "hex": "0084",
+          "name": "SCSI",
+          "value": 132
+        },
+        "slot": {
+          "bus": 5,
+          "number": 0
+        },
+        "base_class": {
+          "hex": "0106",
+          "name": "Mass Storage Device",
+          "value": 262
+        },
+        "sub_class": {
+          "hex": "0000",
+          "name": "Disk",
+          "value": 0
+        },
+        "vendor": {
+          "hex": "090c",
+          "name": "USB",
+          "value": 2316
+        },
+        "device": {
+          "hex": "3267",
+          "name": "Flash Disk",
+          "value": 12903
+        },
+        "revision": {
+          "hex": "0000",
+          "name": "1100",
+          "value": 0
+        },
+        "serial": "AA00000000000489",
+        "model": "USB Flash Disk",
+        "sysfs_id": "/class/block/sdb",
+        "sysfs_bus_id": "5:0:0:0",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:14.0/usb2/2-3/2-3:1.0/host5/target5:0:0/5:0:0:0",
+        "unix_device_names": [
+          "/dev/disk/by-id/usb-USB_Flash_Disk_SCY0000000008850-0:0",
+          "/dev/disk/by-path/pci-0000:00:14.0-usb-0:3:1.0-scsi-0:0:0:0",
+          "/dev/disk/by-path/pci-0000:00:14.0-usbv3-0:3:1.0-scsi-0:0:0:0",
+          "/dev/sdb"
+        ],
+        "unix_device_name2": "/dev/sg1",
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 15200,
+            "heads": 64,
+            "sectors": 32,
+            "size": "0x0",
+            "geo_type": "logical"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 31129600,
+            "value_2": 512
+          }
+        ],
+        "driver": "usb-storage",
+        "driver_module": "usb_storage",
+        "drivers": [
+          "sd",
+          "usb-storage"
+        ],
+        "driver_modules": [
+          "sd_mod",
+          "usb_storage"
+        ],
+        "module_alias": "usb:v090Cp3267d1100dc00dsc00dp00ic08isc06ip50in00"
+      },
+      {
+        "index": 30,
+        "attached_to": 10,
+        "class_list": [
+          "disk",
+          "ide",
+          "block_device"
+        ],
+        "bus_type": {
+          "hex": "0085",
+          "name": "IDE",
+          "value": 133
+        },
+        "slot": {
+          "bus": 0,
+          "number": 0
+        },
+        "base_class": {
+          "hex": "0106",
+          "name": "Mass Storage Device",
+          "value": 262
+        },
+        "sub_class": {
+          "hex": "0000",
+          "name": "Disk",
+          "value": 0
+        },
+        "device": {
+          "hex": "0000",
+          "name": "SSDPR-CX400-512-",
+          "value": 0
+        },
+        "revision": {
+          "hex": "0000",
+          "name": "000C",
+          "value": 0
+        },
+        "serial": "4S0218458",
+        "model": "SSDPR-CX400-512-",
+        "sysfs_id": "/class/block/sda",
+        "sysfs_bus_id": "0:0:0:0",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:17.0/ata1/host0/target0:0:0/0:0:0:0",
+        "unix_device_names": [
+          "/dev/disk/by-id/ata-SSDPR-CX400-512-G2_4S0218458",
+          "/dev/disk/by-id/wwn-0x53a5a27000001858",
+          "/dev/disk/by-path/pci-0000:00:17.0-ata-1",
+          "/dev/disk/by-path/pci-0000:00:17.0-ata-1.0",
+          "/dev/sda"
+        ],
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 62260,
+            "heads": 255,
+            "sectors": 63,
+            "size": "0x0",
+            "geo_type": "logical"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 1000215216,
+            "value_2": 512
+          }
+        ],
+        "driver": "ahci",
+        "driver_module": "ahci",
+        "drivers": [
+          "ahci",
+          "sd"
+        ],
+        "driver_modules": [
+          "ahci",
+          "sd_mod"
+        ]
+      }
+    ],
+    "graphics_card": [
+      {
+        "index": 23,
+        "attached_to": 0,
+        "class_list": [
+          "graphics_card",
+          "pci"
+        ],
+        "bus_type": {
+          "hex": "0004",
+          "name": "PCI",
+          "value": 4
+        },
+        "slot": {
+          "bus": 0,
+          "number": 2
+        },
+        "base_class": {
+          "hex": "0003",
+          "name": "Display controller",
+          "value": 3
+        },
+        "sub_class": {
+          "hex": "0000",
+          "name": "VGA compatible controller",
+          "value": 0
+        },
+        "pci_interface": {
+          "hex": "0000",
+          "name": "VGA",
+          "value": 0
+        },
+        "vendor": {
+          "hex": "8086",
+          "name": "Intel Corporation",
+          "value": 32902
+        },
+        "sub_vendor": {
+          "hex": "1028",
+          "value": 4136
+        },
+        "device": {
+          "hex": "3e92",
+          "value": 16018
+        },
+        "sub_device": {
+          "hex": "085c",
+          "value": 2140
+        },
+        "model": "Intel VGA compatible controller",
+        "sysfs_id": "/devices/pci0000:00/0000:00:02.0",
+        "sysfs_bus_id": "0000:00:02.0",
+        "resources": [
+          {
+            "type": "io",
+            "base": 16384,
+            "range": 64,
+            "enabled": true,
+            "access": "read_write"
+          }
+        ],
+        "detail": {
+          "function": 0,
+          "command": 1031,
+          "header_type": 0,
+          "secondary_bus": 0,
+          "prog_if": 0
+        },
+        "driver": "i915",
+        "driver_module": "i915",
+        "drivers": [
+          "i915"
+        ],
+        "driver_modules": [
+          "i915"
+        ],
+        "module_alias": "pci:v00008086d00003E92sv00001028sd0000085Cbc03sc00i00",
+        "label": "Onboard - Video"
+      }
+    ],
+    "hub": [
+      {
+        "index": 34,
+        "attached_to": 24,
+        "class_list": [
+          "usb",
+          "hub"
+        ],
+        "bus_type": {
+          "hex": "0086",
+          "name": "USB",
+          "value": 134
+        },
+        "slot": {
+          "bus": 0,
+          "number": 0
+        },
+        "base_class": {
+          "hex": "010a",
+          "name": "Hub",
+          "value": 266
+        },
+        "vendor": {
+          "hex": "1d6b",
+          "name": "Linux 6.18.35 xhci-hcd",
+          "value": 7531
+        },
+        "device": {
+          "hex": "0002",
+          "name": "xHCI Host Controller",
+          "value": 2
+        },
+        "revision": {
+          "hex": "0000",
+          "name": "6.18",
+          "value": 0
+        },
+        "serial": "0000:00:14.0",
+        "model": "Linux 6.18.35 xhci-hcd xHCI Host Controller",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0/usb1/1-0:1.0",
+        "sysfs_bus_id": "1-0:1.0",
+        "resources": [
+          {
+            "type": "baud",
+            "speed": 480000000,
+            "bits": 0,
+            "stop_bits": 0,
+            "parity": 0,
+            "handshake": 0
+          }
+        ],
+        "detail": {
+          "device_class": {
+            "hex": "0009",
+            "name": "hub",
+            "value": 9
+          },
+          "device_subclass": {
+            "hex": "0000",
+            "name": "per_interface",
+            "value": 0
+          },
+          "device_protocol": 1,
+          "interface_class": {
+            "hex": "0009",
+            "name": "hub",
+            "value": 9
+          },
+          "interface_subclass": {
+            "hex": "0000",
+            "name": "per_interface",
+            "value": 0
+          },
+          "interface_protocol": 0,
+          "interface_number": 0,
+          "interface_alternate_setting": 0
+        },
+        "hotplug": "usb",
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "drivers": [
+          "hub"
+        ],
+        "driver_modules": [
+          "usbcore"
+        ],
+        "module_alias": "usb:v1D6Bp0002d0618dc09dsc00dp01ic09isc00ip00in00"
+      },
+      {
+        "index": 38,
+        "attached_to": 24,
+        "class_list": [
+          "usb",
+          "hub"
+        ],
+        "bus_type": {
+          "hex": "0086",
+          "name": "USB",
+          "value": 134
+        },
+        "slot": {
+          "bus": 0,
+          "number": 0
+        },
+        "base_class": {
+          "hex": "010a",
+          "name": "Hub",
+          "value": 266
+        },
+        "vendor": {
+          "hex": "1d6b",
+          "name": "Linux 6.18.35 xhci-hcd",
+          "value": 7531
+        },
+        "device": {
+          "hex": "0003",
+          "name": "xHCI Host Controller",
+          "value": 3
+        },
+        "revision": {
+          "hex": "0000",
+          "name": "6.18",
+          "value": 0
+        },
+        "serial": "0000:00:14.0",
+        "model": "Linux 6.18.35 xhci-hcd xHCI Host Controller",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0/usb2/2-0:1.0",
+        "sysfs_bus_id": "2-0:1.0",
+        "detail": {
+          "device_class": {
+            "hex": "0009",
+            "name": "hub",
+            "value": 9
+          },
+          "device_subclass": {
+            "hex": "0000",
+            "name": "per_interface",
+            "value": 0
+          },
+          "device_protocol": 3,
+          "interface_class": {
+            "hex": "0009",
+            "name": "hub",
+            "value": 9
+          },
+          "interface_subclass": {
+            "hex": "0000",
+            "name": "per_interface",
+            "value": 0
+          },
+          "interface_protocol": 0,
+          "interface_number": 0,
+          "interface_alternate_setting": 0
+        },
+        "hotplug": "usb",
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "drivers": [
+          "hub"
+        ],
+        "driver_modules": [
+          "usbcore"
+        ],
+        "module_alias": "usb:v1D6Bp0003d0618dc09dsc00dp03ic09isc00ip00in00"
+      }
+    ],
+    "keyboard": [
+      {
+        "index": 32,
+        "attached_to": 34,
+        "class_list": [
+          "keyboard",
+          "usb"
+        ],
+        "bus_type": {
+          "hex": "0086",
+          "name": "USB",
+          "value": 134
+        },
+        "slot": {
+          "bus": 0,
+          "number": 0
+        },
+        "base_class": {
+          "hex": "0108",
+          "name": "Keyboard",
+          "value": 264
+        },
+        "sub_class": {
+          "hex": "0000",
+          "name": "Keyboard",
+          "value": 0
+        },
+        "vendor": {
+          "hex": "04d9",
+          "name": "Holtek Microelectronics Inc.",
+          "value": 1241
+        },
+        "device": {
+          "hex": "1836",
+          "name": "Mechanical Keyboard",
+          "value": 6198
+        },
+        "revision": {
+          "hex": "0000",
+          "name": "0.01",
+          "value": 0
+        },
+        "model": "Holtek Microelectronics Mechanical Keyboard",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0/usb1/1-7/1-7:1.0",
+        "sysfs_bus_id": "1-7:1.0",
+        "unix_device_names": [
+          "/dev/input/by-id/usb-LogoTech_Mechanical_Keyboard-event-kbd",
+          "/dev/input/by-path/pci-0000:00:14.0-usb-0:7:1.0-event-kbd",
+          "/dev/input/by-path/pci-0000:00:14.0-usbv2-0:7:1.0-event-kbd",
+          "/dev/input/event4"
+        ],
+        "resources": [
+          {
+            "type": "baud",
+            "speed": 1500000,
+            "bits": 0,
+            "stop_bits": 0,
+            "parity": 0,
+            "handshake": 0
+          }
+        ],
+        "detail": {
+          "device_class": {
+            "hex": "0000",
+            "name": "per_interface",
+            "value": 0
+          },
+          "device_subclass": {
+            "hex": "0000",
+            "name": "per_interface",
+            "value": 0
+          },
+          "device_protocol": 0,
+          "interface_class": {
+            "hex": "0003",
+            "name": "hid",
+            "value": 3
+          },
+          "interface_subclass": {
+            "hex": "0001",
+            "name": "audio",
+            "value": 1
+          },
+          "interface_protocol": 1,
+          "interface_number": 0,
+          "interface_alternate_setting": 0
+        },
+        "hotplug": "usb",
+        "driver": "usbhid",
+        "driver_module": "usbhid",
+        "drivers": [
+          "usbhid"
+        ],
+        "driver_modules": [
+          "usbhid"
+        ],
+        "driver_info": {
+          "type": "keyboard",
+          "xkb_rules": "xfree86",
+          "xkb_model": "pc104"
+        },
+        "module_alias": "usb:v04D9p1836d0001dc00dsc00dp00ic03isc01ip01in00"
+      },
+      {
+        "index": 35,
+        "attached_to": 34,
+        "class_list": [
+          "keyboard",
+          "usb"
+        ],
+        "bus_type": {
+          "hex": "0086",
+          "name": "USB",
+          "value": 134
+        },
+        "slot": {
+          "bus": 0,
+          "number": 0
+        },
+        "base_class": {
+          "hex": "0108",
+          "name": "Keyboard",
+          "value": 264
+        },
+        "sub_class": {
+          "hex": "0000",
+          "name": "Keyboard",
+          "value": 0
+        },
+        "vendor": {
+          "hex": "09da",
+          "name": "COMPANY",
+          "value": 2522
+        },
+        "device": {
+          "hex": "1047",
+          "name": "USB Device",
+          "value": 4167
+        },
+        "revision": {
+          "hex": "0000",
+          "name": "0.0f",
+          "value": 0
+        },
+        "model": "COMPANY USB Device",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0/usb1/1-4/1-4:1.0",
+        "sysfs_bus_id": "1-4:1.0",
+        "unix_device_names": [
+          "/dev/input/by-id/usb-COMPANY_USB_Device-event-kbd",
+          "/dev/input/by-path/pci-0000:00:14.0-usb-0:4:1.0-event-kbd",
+          "/dev/input/by-path/pci-0000:00:14.0-usbv2-0:4:1.0-event-kbd",
+          "/dev/input/event0"
+        ],
+        "resources": [
+          {
+            "type": "baud",
+            "speed": 12000000,
+            "bits": 0,
+            "stop_bits": 0,
+            "parity": 0,
+            "handshake": 0
+          }
+        ],
+        "detail": {
+          "device_class": {
+            "hex": "0000",
+            "name": "per_interface",
+            "value": 0
+          },
+          "device_subclass": {
+            "hex": "0000",
+            "name": "per_interface",
+            "value": 0
+          },
+          "device_protocol": 0,
+          "interface_class": {
+            "hex": "0003",
+            "name": "hid",
+            "value": 3
+          },
+          "interface_subclass": {
+            "hex": "0001",
+            "name": "audio",
+            "value": 1
+          },
+          "interface_protocol": 1,
+          "interface_number": 0,
+          "interface_alternate_setting": 0
+        },
+        "hotplug": "usb",
+        "driver": "usbhid",
+        "driver_module": "usbhid",
+        "drivers": [
+          "usbhid"
+        ],
+        "driver_modules": [
+          "usbhid"
+        ],
+        "driver_info": {
+          "type": "keyboard",
+          "xkb_rules": "xfree86",
+          "xkb_model": "pc104"
+        },
+        "module_alias": "usb:v09DAp1047d000Fdc00dsc00dp00ic03isc01ip01in00"
+      }
+    ],
+    "memory": [
+      {
+        "index": 9,
+        "attached_to": 0,
+        "class_list": [
+          "memory"
+        ],
+        "base_class": {
+          "hex": "0101",
+          "name": "Internally Used Class",
+          "value": 257
+        },
+        "sub_class": {
+          "hex": "0002",
+          "name": "Main Memory",
+          "value": 2
+        },
+        "model": "Main Memory",
+        "resources": [
+          {
+            "type": "phys_mem",
+            "range": 34359738368
+          }
+        ]
+      }
+    ],
+    "monitor": [
+      {
+        "index": 26,
+        "attached_to": 23,
+        "class_list": [
+          "monitor"
+        ],
+        "base_class": {
+          "hex": "0100",
+          "name": "Monitor",
+          "value": 256
+        },
+        "sub_class": {
+          "hex": "0002",
+          "name": "LCD Monitor",
+          "value": 2
+        },
+        "vendor": {
+          "hex": "3669",
+          "value": 13929
+        },
+        "device": {
+          "hex": "3dc0",
+          "name": "MSI G273CQ",
+          "value": 15808
+        },
+        "serial": "CD0H014500501",
+        "model": "MSI G273CQ",
+        "resources": [
+          {
+            "type": "monitor",
+            "width": 1024,
+            "height": 768,
+            "vertical_frequency": 60,
+            "interlaced": false
+          },
+          {
+            "type": "monitor",
+            "width": 1024,
+            "height": 768,
+            "vertical_frequency": 70,
+            "interlaced": false
+          },
+          {
+            "type": "monitor",
+            "width": 1024,
+            "height": 768,
+            "vertical_frequency": 75,
+            "interlaced": false
+          },
+          {
+            "type": "monitor",
+            "width": 1280,
+            "height": 1024,
+            "vertical_frequency": 60,
+            "interlaced": false
+          },
+          {
+            "type": "monitor",
+            "width": 1280,
+            "height": 1024,
+            "vertical_frequency": 75,
+            "interlaced": false
+          },
+          {
+            "type": "monitor",
+            "width": 2560,
+            "height": 1440,
+            "vertical_frequency": 60,
+            "interlaced": false
+          },
+          {
+            "type": "monitor",
+            "width": 640,
+            "height": 480,
+            "vertical_frequency": 60,
+            "interlaced": false
+          },
+          {
+            "type": "monitor",
+            "width": 640,
+            "height": 480,
+            "vertical_frequency": 67,
+            "interlaced": false
+          },
+          {
+            "type": "monitor",
+            "width": 640,
+            "height": 480,
+            "vertical_frequency": 72,
+            "interlaced": false
+          },
+          {
+            "type": "monitor",
+            "width": 640,
+            "height": 480,
+            "vertical_frequency": 75,
+            "interlaced": false
+          },
+          {
+            "type": "monitor",
+            "width": 800,
+            "height": 600,
+            "vertical_frequency": 56,
+            "interlaced": false
+          },
+          {
+            "type": "monitor",
+            "width": 800,
+            "height": 600,
+            "vertical_frequency": 60,
+            "interlaced": false
+          },
+          {
+            "type": "monitor",
+            "width": 800,
+            "height": 600,
+            "vertical_frequency": 72,
+            "interlaced": false
+          },
+          {
+            "type": "monitor",
+            "width": 800,
+            "height": 600,
+            "vertical_frequency": 75,
+            "interlaced": false
+          },
+          {
+            "type": "size",
+            "unit": "mm",
+            "value_1": 597,
+            "value_2": 336
+          }
+        ],
+        "detail": {
+          "manufacture_year": 2024,
+          "manufacture_week": 20,
+          "vertical_sync": {
+            "min": 48,
+            "max": 165
+          },
+          "horizontal_sync": {
+            "min": 215,
+            "max": 215
+          },
+          "horizontal_sync_timings": {
+            "disp": 2560,
+            "sync_start": 2608,
+            "sync_end": 2640,
+            "total": 2720
+          },
+          "vertical_sync_timings": {
+            "disp": 1440,
+            "sync_start": 1443,
+            "sync_end": 1448,
+            "total": 1481
+          },
+          "clock": 241500,
+          "width": 2560,
+          "height": 1440,
+          "width_millimetres": 597,
+          "height_millimetres": 336,
+          "horizontal_flag": 45,
+          "vertical_flag": 43,
+          "vendor": "",
+          "name": "MSI G273CQ"
+        },
+        "driver_info": {
+          "type": "display",
+          "width": 2560,
+          "height": 1440,
+          "vertical_sync": {
+            "min": 48,
+            "max": 165
+          },
+          "horizontal_sync": {
+            "min": 215,
+            "max": 215
+          },
+          "bandwidth": 0,
+          "horizontal_sync_timings": {
+            "disp": 2560,
+            "sync_start": 2608,
+            "sync_end": 2640,
+            "total": 2720
+          },
+          "vertical_sync_timings": {
+            "disp": 1440,
+            "sync_start": 1443,
+            "sync_end": 1448,
+            "total": 1481
+          },
+          "horizontal_flag": 45,
+          "vertical_flag": 43
+        }
+      }
+    ],
+    "mouse": [
+      {
+        "index": 31,
+        "attached_to": 34,
+        "class_list": [
+          "mouse",
+          "usb"
+        ],
+        "bus_type": {
+          "hex": "0086",
+          "name": "USB",
+          "value": 134
+        },
+        "slot": {
+          "bus": 0,
+          "number": 0
+        },
+        "base_class": {
+          "hex": "0105",
+          "name": "Mouse",
+          "value": 261
+        },
+        "sub_class": {
+          "hex": "0003",
+          "name": "USB Mouse",
+          "value": 3
+        },
+        "vendor": {
+          "hex": "09da",
+          "name": "COMPANY",
+          "value": 2522
+        },
+        "device": {
+          "hex": "1047",
+          "name": "USB Device",
+          "value": 4167
+        },
+        "revision": {
+          "hex": "0000",
+          "name": "0.0f",
+          "value": 0
+        },
+        "compat_vendor": "Unknown",
+        "compat_device": "Generic USB Mouse",
+        "model": "COMPANY USB Device",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0/usb1/1-4/1-4:1.1",
+        "sysfs_bus_id": "1-4:1.1",
+        "unix_device_names": [
+          "/dev/input/mice"
+        ],
+        "unix_device_name2": "/dev/input/mouse0",
+        "resources": [
+          {
+            "type": "baud",
+            "speed": 12000000,
+            "bits": 0,
+            "stop_bits": 0,
+            "parity": 0,
+            "handshake": 0
+          }
+        ],
+        "detail": {
+          "device_class": {
+            "hex": "0000",
+            "name": "per_interface",
+            "value": 0
+          },
+          "device_subclass": {
+            "hex": "0000",
+            "name": "per_interface",
+            "value": 0
+          },
+          "device_protocol": 0,
+          "interface_class": {
+            "hex": "0003",
+            "name": "hid",
+            "value": 3
+          },
+          "interface_subclass": {
+            "hex": "0001",
+            "name": "audio",
+            "value": 1
+          },
+          "interface_protocol": 2,
+          "interface_number": 1,
+          "interface_alternate_setting": 0
+        },
+        "hotplug": "usb",
+        "driver": "usbhid",
+        "driver_module": "usbhid",
+        "drivers": [
+          "usbhid"
+        ],
+        "driver_modules": [
+          "usbhid"
+        ],
+        "driver_info": {
+          "type": "mouse",
+          "db_entry_0": [
+            "explorerps/2",
+            "exps2"
+          ],
+          "xf86": "explorerps/2",
+          "gpm": "exps2",
+          "buttons": -1,
+          "wheels": -1
+        },
+        "module_alias": "usb:v09DAp1047d000Fdc00dsc00dp00ic03isc01ip02in01"
+      }
+    ],
+    "network_controller": [
+      {
+        "index": 16,
+        "attached_to": 11,
+        "class_list": [
+          "network_controller",
+          "pci"
+        ],
+        "bus_type": {
+          "hex": "0004",
+          "name": "PCI",
+          "value": 4
+        },
+        "slot": {
+          "bus": 1,
+          "number": 0
+        },
+        "base_class": {
+          "hex": "0002",
+          "name": "Network controller",
+          "value": 2
+        },
+        "sub_class": {
+          "hex": "0000",
+          "name": "Ethernet controller",
+          "value": 0
+        },
+        "vendor": {
+          "hex": "10ec",
+          "value": 4332
+        },
+        "sub_vendor": {
+          "hex": "1028",
+          "value": 4136
+        },
+        "device": {
+          "hex": "8168",
+          "value": 33128
+        },
+        "sub_device": {
+          "hex": "085c",
+          "value": 2140
+        },
+        "revision": {
+          "hex": "0015",
+          "value": 21
+        },
+        "model": "Ethernet controller",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1c.0/0000:01:00.0",
+        "sysfs_bus_id": "0000:01:00.0",
+        "unix_device_names": [
+          "enp1s0"
+        ],
+        "resources": [
+          {
+            "type": "hwaddr",
+            "address": 101
+          },
+          {
+            "type": "io",
+            "base": 12288,
+            "range": 256,
+            "enabled": true,
+            "access": "read_write"
+          },
+          {
+            "type": "phwaddr",
+            "address": 101
+          }
+        ],
+        "detail": {
+          "function": 0,
+          "command": 1287,
+          "header_type": 0,
+          "secondary_bus": 0,
+          "prog_if": 0
+        },
+        "driver": "r8169",
+        "driver_module": "r8169",
+        "drivers": [
+          "r8169"
+        ],
+        "driver_modules": [
+          "r8169"
+        ],
+        "module_alias": "pci:v000010ECd00008168sv00001028sd0000085Cbc02sc00i00"
+      }
+    ],
+    "network_interface": [
+      {
+        "index": 39,
+        "attached_to": 16,
+        "class_list": [
+          "network_interface"
+        ],
+        "base_class": {
+          "hex": "0107",
+          "name": "Network Interface",
+          "value": 263
+        },
+        "sub_class": {
+          "hex": "0001",
+          "name": "Ethernet",
+          "value": 1
+        },
+        "model": "Ethernet network interface",
+        "sysfs_id": "/class/net/enp1s0",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:1c.0/0000:01:00.0",
+        "unix_device_names": [
+          "enp1s0"
+        ],
+        "resources": [
+          {
+            "type": "hwaddr",
+            "address": 101
+          },
+          {
+            "type": "phwaddr",
+            "address": 101
+          }
+        ],
+        "driver": "r8169",
+        "driver_module": "r8169",
+        "drivers": [
+          "r8169"
+        ],
+        "driver_modules": [
+          "r8169"
+        ]
+      },
+      {
+        "index": 40,
+        "attached_to": 0,
+        "class_list": [
+          "network_interface"
+        ],
+        "base_class": {
+          "hex": "0107",
+          "name": "Network Interface",
+          "value": 263
+        },
+        "sub_class": {
+          "hex": "0000",
+          "name": "Loopback",
+          "value": 0
+        },
+        "model": "Loopback network interface",
+        "sysfs_id": "/class/net/lo",
+        "unix_device_names": [
+          "lo"
+        ]
+      }
+    ],
+    "pci": [
+      {
+        "index": 12,
+        "attached_to": 0,
+        "class_list": [
+          "pci",
+          "unknown"
+        ],
+        "bus_type": {
+          "hex": "0004",
+          "name": "PCI",
+          "value": 4
+        },
+        "slot": {
+          "bus": 0,
+          "number": 8
+        },
+        "base_class": {
+          "hex": "0008",
+          "name": "Generic system peripheral",
+          "value": 8
+        },
+        "sub_class": {
+          "hex": "0080",
+          "name": "System peripheral",
+          "value": 128
+        },
+        "vendor": {
+          "hex": "8086",
+          "name": "Intel Corporation",
+          "value": 32902
+        },
+        "sub_vendor": {
+          "hex": "1028",
+          "value": 4136
+        },
+        "device": {
+          "hex": "1911",
+          "value": 6417
+        },
+        "sub_device": {
+          "hex": "085c",
+          "value": 2140
+        },
+        "model": "Intel System peripheral",
+        "sysfs_id": "/devices/pci0000:00/0000:00:08.0",
+        "sysfs_bus_id": "0000:00:08.0",
+        "detail": {
+          "function": 0,
+          "command": 0,
+          "header_type": 0,
+          "secondary_bus": 0,
+          "prog_if": 0
+        },
+        "module_alias": "pci:v00008086d00001911sv00001028sd0000085Cbc08sc80i00",
+        "label": "Onboard - Other"
+      },
+      {
+        "index": 15,
+        "attached_to": 0,
+        "class_list": [
+          "pci",
+          "unknown"
+        ],
+        "bus_type": {
+          "hex": "0004",
+          "name": "PCI",
+          "value": 4
+        },
+        "slot": {
+          "bus": 0,
+          "number": 22
+        },
+        "base_class": {
+          "hex": "0007",
+          "name": "Communication controller",
+          "value": 7
+        },
+        "sub_class": {
+          "hex": "0080",
+          "name": "Communication controller",
+          "value": 128
+        },
+        "vendor": {
+          "hex": "8086",
+          "name": "Intel Corporation",
+          "value": 32902
+        },
+        "sub_vendor": {
+          "hex": "1028",
+          "value": 4136
+        },
+        "device": {
+          "hex": "a360",
+          "value": 41824
+        },
+        "sub_device": {
+          "hex": "085c",
+          "value": 2140
+        },
+        "revision": {
+          "hex": "0010",
+          "value": 16
+        },
+        "model": "Intel Communication controller",
+        "sysfs_id": "/devices/pci0000:00/0000:00:16.0",
+        "sysfs_bus_id": "0000:00:16.0",
+        "detail": {
+          "function": 0,
+          "command": 1030,
+          "header_type": 0,
+          "secondary_bus": 0,
+          "prog_if": 0
+        },
+        "driver": "mei_me",
+        "driver_module": "mei_me",
+        "drivers": [
+          "mei_me"
+        ],
+        "driver_modules": [
+          "mei_me"
+        ],
+        "module_alias": "pci:v00008086d0000A360sv00001028sd0000085Cbc07sc80i00",
+        "label": "Onboard - Other"
+      },
+      {
+        "index": 17,
+        "attached_to": 0,
+        "class_list": [
+          "pci",
+          "unknown"
+        ],
+        "bus_type": {
+          "hex": "0004",
+          "name": "PCI",
+          "value": 4
+        },
+        "slot": {
+          "bus": 0,
+          "number": 31
+        },
+        "base_class": {
+          "hex": "000c",
+          "name": "Serial bus controller",
+          "value": 12
+        },
+        "sub_class": {
+          "hex": "0080",
+          "value": 128
+        },
+        "vendor": {
+          "hex": "8086",
+          "name": "Intel Corporation",
+          "value": 32902
+        },
+        "sub_vendor": {
+          "hex": "1028",
+          "value": 4136
+        },
+        "device": {
+          "hex": "a324",
+          "value": 41764
+        },
+        "sub_device": {
+          "hex": "085c",
+          "value": 2140
+        },
+        "revision": {
+          "hex": "0010",
+          "value": 16
+        },
+        "model": "Intel Serial bus controller",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1f.5",
+        "sysfs_bus_id": "0000:00:1f.5",
+        "detail": {
+          "function": 5,
+          "command": 1282,
+          "header_type": 0,
+          "secondary_bus": 0,
+          "prog_if": 0
+        },
+        "driver": "intel-spi",
+        "driver_module": "spi_intel_pci",
+        "drivers": [
+          "intel-spi"
+        ],
+        "driver_modules": [
+          "spi_intel_pci"
+        ],
+        "module_alias": "pci:v00008086d0000A324sv00001028sd0000085Cbc0Csc80i00",
+        "label": "Onboard - Other"
+      },
+      {
+        "index": 20,
+        "attached_to": 0,
+        "class_list": [
+          "pci",
+          "unknown"
+        ],
+        "bus_type": {
+          "hex": "0004",
+          "name": "PCI",
+          "value": 4
+        },
+        "slot": {
+          "bus": 0,
+          "number": 18
+        },
+        "base_class": {
+          "hex": "0011",
+          "name": "Signal processing controller",
+          "value": 17
+        },
+        "sub_class": {
+          "hex": "0080",
+          "name": "Signal processing controller",
+          "value": 128
+        },
+        "vendor": {
+          "hex": "8086",
+          "name": "Intel Corporation",
+          "value": 32902
+        },
+        "sub_vendor": {
+          "hex": "1028",
+          "value": 4136
+        },
+        "device": {
+          "hex": "a379",
+          "value": 41849
+        },
+        "sub_device": {
+          "hex": "085c",
+          "value": 2140
+        },
+        "revision": {
+          "hex": "0010",
+          "value": 16
+        },
+        "model": "Intel Signal processing controller",
+        "sysfs_id": "/devices/pci0000:00/0000:00:12.0",
+        "sysfs_bus_id": "0000:00:12.0",
+        "detail": {
+          "function": 0,
+          "command": 258,
+          "header_type": 0,
+          "secondary_bus": 0,
+          "prog_if": 0
+        },
+        "driver": "intel_pch_thermal",
+        "driver_module": "intel_pch_thermal",
+        "drivers": [
+          "intel_pch_thermal"
+        ],
+        "driver_modules": [
+          "intel_pch_thermal"
+        ],
+        "module_alias": "pci:v00008086d0000A379sv00001028sd0000085Cbc11sc80i00",
+        "label": "Onboard - Other"
+      },
+      {
+        "index": 22,
+        "attached_to": 0,
+        "class_list": [
+          "pci",
+          "unknown"
+        ],
+        "bus_type": {
+          "hex": "0004",
+          "name": "PCI",
+          "value": 4
+        },
+        "slot": {
+          "bus": 0,
+          "number": 20
+        },
+        "base_class": {
+          "hex": "0005",
+          "name": "Memory controller",
+          "value": 5
+        },
+        "sub_class": {
+          "hex": "0000",
+          "name": "RAM memory",
+          "value": 0
+        },
+        "vendor": {
+          "hex": "8086",
+          "name": "Intel Corporation",
+          "value": 32902
+        },
+        "sub_vendor": {
+          "hex": "8086",
+          "name": "Intel Corporation",
+          "value": 32902
+        },
+        "device": {
+          "hex": "a36f",
+          "value": 41839
+        },
+        "sub_device": {
+          "hex": "7270",
+          "value": 29296
+        },
+        "revision": {
+          "hex": "0010",
+          "value": 16
+        },
+        "model": "Intel RAM memory",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.2",
+        "sysfs_bus_id": "0000:00:14.2",
+        "detail": {
+          "function": 2,
+          "command": 256,
+          "header_type": 0,
+          "secondary_bus": 0,
+          "prog_if": 0
+        },
+        "module_alias": "pci:v00008086d0000A36Fsv00008086sd00007270bc05sc00i00",
+        "label": "Onboard - Other"
+      },
+      {
+        "index": 25,
+        "attached_to": 0,
+        "class_list": [
+          "pci",
+          "unknown"
+        ],
+        "bus_type": {
+          "hex": "0004",
+          "name": "PCI",
+          "value": 4
+        },
+        "slot": {
+          "bus": 0,
+          "number": 31
+        },
+        "base_class": {
+          "hex": "000c",
+          "name": "Serial bus controller",
+          "value": 12
+        },
+        "sub_class": {
+          "hex": "0005",
+          "name": "SMBus",
+          "value": 5
+        },
+        "vendor": {
+          "hex": "8086",
+          "name": "Intel Corporation",
+          "value": 32902
+        },
+        "sub_vendor": {
+          "hex": "1028",
+          "value": 4136
+        },
+        "device": {
+          "hex": "a323",
+          "value": 41763
+        },
+        "sub_device": {
+          "hex": "085c",
+          "value": 2140
+        },
+        "revision": {
+          "hex": "0010",
+          "value": 16
+        },
+        "model": "Intel SMBus",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1f.4",
+        "sysfs_bus_id": "0000:00:1f.4",
+        "resources": [
+          {
+            "type": "io",
+            "base": 61344,
+            "range": 32,
+            "enabled": true,
+            "access": "read_write"
+          }
+        ],
+        "detail": {
+          "function": 4,
+          "command": 259,
+          "header_type": 0,
+          "secondary_bus": 0,
+          "prog_if": 0
+        },
+        "driver": "i801_smbus",
+        "driver_module": "i2c_i801",
+        "drivers": [
+          "i801_smbus"
+        ],
+        "driver_modules": [
+          "i2c_i801"
+        ],
+        "module_alias": "pci:v00008086d0000A323sv00001028sd0000085Cbc0Csc05i00",
+        "label": "Onboard - Other"
+      }
+    ],
+    "sound": [
+      {
+        "index": 18,
+        "attached_to": 0,
+        "class_list": [
+          "sound",
+          "pci"
+        ],
+        "bus_type": {
+          "hex": "0004",
+          "name": "PCI",
+          "value": 4
+        },
+        "slot": {
+          "bus": 0,
+          "number": 31
+        },
+        "base_class": {
+          "hex": "0004",
+          "name": "Multimedia controller",
+          "value": 4
+        },
+        "sub_class": {
+          "hex": "0003",
+          "value": 3
+        },
+        "vendor": {
+          "hex": "8086",
+          "name": "Intel Corporation",
+          "value": 32902
+        },
+        "sub_vendor": {
+          "hex": "1028",
+          "value": 4136
+        },
+        "device": {
+          "hex": "a348",
+          "value": 41800
+        },
+        "sub_device": {
+          "hex": "085c",
+          "value": 2140
+        },
+        "revision": {
+          "hex": "0010",
+          "value": 16
+        },
+        "model": "Intel Multimedia controller",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1f.3",
+        "sysfs_bus_id": "0000:00:1f.3",
+        "detail": {
+          "function": 3,
+          "command": 1286,
+          "header_type": 0,
+          "secondary_bus": 0,
+          "prog_if": 0
+        },
+        "driver": "snd_hda_intel",
+        "driver_module": "snd_hda_intel",
+        "drivers": [
+          "snd_hda_intel"
+        ],
+        "driver_modules": [
+          "snd_hda_intel"
+        ],
+        "module_alias": "pci:v00008086d0000A348sv00001028sd0000085Cbc04sc03i00",
+        "label": "Onboard - Sound"
+      }
+    ],
+    "storage_controller": [
+      {
+        "index": 10,
+        "attached_to": 0,
+        "class_list": [
+          "storage_controller",
+          "pci"
+        ],
+        "bus_type": {
+          "hex": "0004",
+          "name": "PCI",
+          "value": 4
+        },
+        "slot": {
+          "bus": 0,
+          "number": 23
+        },
+        "base_class": {
+          "hex": "0001",
+          "name": "Mass storage controller",
+          "value": 1
+        },
+        "sub_class": {
+          "hex": "0006",
+          "value": 6
+        },
+        "pci_interface": {
+          "hex": "0001",
+          "value": 1
+        },
+        "vendor": {
+          "hex": "8086",
+          "name": "Intel Corporation",
+          "value": 32902
+        },
+        "sub_vendor": {
+          "hex": "1028",
+          "value": 4136
+        },
+        "device": {
+          "hex": "a352",
+          "value": 41810
+        },
+        "sub_device": {
+          "hex": "085c",
+          "value": 2140
+        },
+        "revision": {
+          "hex": "0010",
+          "value": 16
+        },
+        "model": "Intel Mass storage controller",
+        "sysfs_id": "/devices/pci0000:00/0000:00:17.0",
+        "sysfs_bus_id": "0000:00:17.0",
+        "resources": [
+          {
+            "type": "io",
+            "base": 16480,
+            "range": 32,
+            "enabled": true,
+            "access": "read_write"
+          },
+          {
+            "type": "io",
+            "base": 16512,
+            "range": 4,
+            "enabled": true,
+            "access": "read_write"
+          },
+          {
+            "type": "io",
+            "base": 16528,
+            "range": 8,
+            "enabled": true,
+            "access": "read_write"
+          }
+        ],
+        "detail": {
+          "function": 0,
+          "command": 1287,
+          "header_type": 0,
+          "secondary_bus": 0,
+          "prog_if": 1
+        },
+        "driver": "ahci",
+        "driver_module": "ahci",
+        "drivers": [
+          "ahci"
+        ],
+        "driver_modules": [
+          "ahci"
+        ],
+        "module_alias": "pci:v00008086d0000A352sv00001028sd0000085Cbc01sc06i01",
+        "label": "Onboard - SATA"
+      },
+      {
+        "index": 14,
+        "attached_to": 21,
+        "class_list": [
+          "storage_controller",
+          "pci"
+        ],
+        "bus_type": {
+          "hex": "0004",
+          "name": "PCI",
+          "value": 4
+        },
+        "slot": {
+          "bus": 2,
+          "number": 0
+        },
+        "base_class": {
+          "hex": "0001",
+          "name": "Mass storage controller",
+          "value": 1
+        },
+        "sub_class": {
+          "hex": "0008",
+          "value": 8
+        },
+        "pci_interface": {
+          "hex": "0002",
+          "value": 2
+        },
+        "vendor": {
+          "hex": "144d",
+          "value": 5197
+        },
+        "sub_vendor": {
+          "hex": "144d",
+          "value": 5197
+        },
+        "device": {
+          "hex": "a809",
+          "value": 43017
+        },
+        "sub_device": {
+          "hex": "a801",
+          "value": 43009
+        },
+        "model": "Mass storage controller",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1d.0/0000:02:00.0",
+        "sysfs_bus_id": "0000:02:00.0",
+        "detail": {
+          "function": 0,
+          "command": 1286,
+          "header_type": 0,
+          "secondary_bus": 0,
+          "prog_if": 2
+        },
+        "driver": "nvme",
+        "driver_module": "nvme",
+        "drivers": [
+          "nvme"
+        ],
+        "driver_modules": [
+          "nvme"
+        ],
+        "module_alias": "pci:v0000144Dd0000A809sv0000144Dsd0000A801bc01sc08i02"
+      }
+    ],
+    "system": {
+      "form_factor": "laptop"
+    },
+    "unknown": [
+      {
+        "index": 27,
+        "attached_to": 0,
+        "class_list": [
+          "unknown"
+        ],
+        "base_class": {
+          "hex": "0007",
+          "name": "Communication controller",
+          "value": 7
+        },
+        "sub_class": {
+          "hex": "0000",
+          "name": "Serial controller",
+          "value": 0
+        },
+        "pci_interface": {
+          "hex": "0002",
+          "name": "16550",
+          "value": 2
+        },
+        "device": {
+          "hex": "0000",
+          "name": "16550A",
+          "value": 0
+        },
+        "model": "16550A",
+        "unix_device_names": [
+          "/dev/ttyS0"
+        ],
+        "resources": [
+          {
+            "type": "io",
+            "base": 1016,
+            "range": 0,
+            "enabled": true,
+            "access": "read_write"
+          }
+        ]
+      }
+    ],
+    "usb": [
+      {
+        "index": 33,
+        "attached_to": 34,
+        "class_list": [
+          "usb",
+          "unknown"
+        ],
+        "bus_type": {
+          "hex": "0086",
+          "name": "USB",
+          "value": 134
+        },
+        "slot": {
+          "bus": 0,
+          "number": 0
+        },
+        "base_class": {
+          "hex": "0000",
+          "name": "Unclassified device",
+          "value": 0
+        },
+        "sub_class": {
+          "hex": "0000",
+          "name": "Unclassified device",
+          "value": 0
+        },
+        "vendor": {
+          "hex": "09da",
+          "name": "COMPANY",
+          "value": 2522
+        },
+        "device": {
+          "hex": "1047",
+          "name": "USB Device",
+          "value": 4167
+        },
+        "revision": {
+          "hex": "0000",
+          "name": "0.0f",
+          "value": 0
+        },
+        "model": "COMPANY USB Device",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0/usb1/1-4/1-4:1.2",
+        "sysfs_bus_id": "1-4:1.2",
+        "unix_device_names": [
+          "/dev/input/by-id/usb-COMPANY_USB_Device-event-if02",
+          "/dev/input/by-path/pci-0000:00:14.0-usb-0:4:1.2-event",
+          "/dev/input/by-path/pci-0000:00:14.0-usbv2-0:4:1.2-event",
+          "/dev/input/event3"
+        ],
+        "resources": [
+          {
+            "type": "baud",
+            "speed": 12000000,
+            "bits": 0,
+            "stop_bits": 0,
+            "parity": 0,
+            "handshake": 0
+          }
+        ],
+        "detail": {
+          "device_class": {
+            "hex": "0000",
+            "name": "per_interface",
+            "value": 0
+          },
+          "device_subclass": {
+            "hex": "0000",
+            "name": "per_interface",
+            "value": 0
+          },
+          "device_protocol": 0,
+          "interface_class": {
+            "hex": "0003",
+            "name": "hid",
+            "value": 3
+          },
+          "interface_subclass": {
+            "hex": "0000",
+            "name": "per_interface",
+            "value": 0
+          },
+          "interface_protocol": 0,
+          "interface_number": 2,
+          "interface_alternate_setting": 0
+        },
+        "hotplug": "usb",
+        "driver": "usbhid",
+        "driver_module": "usbhid",
+        "drivers": [
+          "usbhid"
+        ],
+        "driver_modules": [
+          "usbhid"
+        ],
+        "module_alias": "usb:v09DAp1047d000Fdc00dsc00dp00ic03isc00ip00in02"
+      },
+      {
+        "index": 37,
+        "attached_to": 34,
+        "class_list": [
+          "usb",
+          "unknown"
+        ],
+        "bus_type": {
+          "hex": "0086",
+          "name": "USB",
+          "value": 134
+        },
+        "slot": {
+          "bus": 0,
+          "number": 0
+        },
+        "base_class": {
+          "hex": "0000",
+          "name": "Unclassified device",
+          "value": 0
+        },
+        "sub_class": {
+          "hex": "0000",
+          "name": "Unclassified device",
+          "value": 0
+        },
+        "vendor": {
+          "hex": "04d9",
+          "name": "Holtek Microelectronics Inc.",
+          "value": 1241
+        },
+        "device": {
+          "hex": "1836",
+          "name": "Mechanical Keyboard",
+          "value": 6198
+        },
+        "revision": {
+          "hex": "0000",
+          "name": "0.01",
+          "value": 0
+        },
+        "model": "Holtek Microelectronics Mechanical Keyboard",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0/usb1/1-7/1-7:1.1",
+        "sysfs_bus_id": "1-7:1.1",
+        "unix_device_names": [
+          "/dev/input/event7"
+        ],
+        "resources": [
+          {
+            "type": "baud",
+            "speed": 1500000,
+            "bits": 0,
+            "stop_bits": 0,
+            "parity": 0,
+            "handshake": 0
+          }
+        ],
+        "detail": {
+          "device_class": {
+            "hex": "0000",
+            "name": "per_interface",
+            "value": 0
+          },
+          "device_subclass": {
+            "hex": "0000",
+            "name": "per_interface",
+            "value": 0
+          },
+          "device_protocol": 0,
+          "interface_class": {
+            "hex": "0003",
+            "name": "hid",
+            "value": 3
+          },
+          "interface_subclass": {
+            "hex": "0000",
+            "name": "per_interface",
+            "value": 0
+          },
+          "interface_protocol": 0,
+          "interface_number": 1,
+          "interface_alternate_setting": 0
+        },
+        "hotplug": "usb",
+        "driver": "usbhid",
+        "driver_module": "usbhid",
+        "drivers": [
+          "usbhid"
+        ],
+        "driver_modules": [
+          "usbhid"
+        ],
+        "module_alias": "usb:v04D9p1836d0001dc00dsc00dp00ic03isc00ip00in01"
+      }
+    ],
+    "usb_controller": [
+      {
+        "index": 24,
+        "attached_to": 0,
+        "class_list": [
+          "usb_controller",
+          "pci"
+        ],
+        "bus_type": {
+          "hex": "0004",
+          "name": "PCI",
+          "value": 4
+        },
+        "slot": {
+          "bus": 0,
+          "number": 20
+        },
+        "base_class": {
+          "hex": "000c",
+          "name": "Serial bus controller",
+          "value": 12
+        },
+        "sub_class": {
+          "hex": "0003",
+          "name": "USB Controller",
+          "value": 3
+        },
+        "pci_interface": {
+          "hex": "0030",
+          "value": 48
+        },
+        "vendor": {
+          "hex": "8086",
+          "name": "Intel Corporation",
+          "value": 32902
+        },
+        "sub_vendor": {
+          "hex": "1028",
+          "value": 4136
+        },
+        "device": {
+          "hex": "a36d",
+          "value": 41837
+        },
+        "sub_device": {
+          "hex": "085c",
+          "value": 2140
+        },
+        "revision": {
+          "hex": "0010",
+          "value": 16
+        },
+        "model": "Intel USB Controller",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0",
+        "sysfs_bus_id": "0000:00:14.0",
+        "detail": {
+          "function": 0,
+          "command": 1286,
+          "header_type": 0,
+          "secondary_bus": 0,
+          "prog_if": 48
+        },
+        "driver": "xhci_hcd",
+        "driver_module": "xhci_pci",
+        "drivers": [
+          "xhci_hcd"
+        ],
+        "driver_modules": [
+          "xhci_pci"
+        ],
+        "module_alias": "pci:v00008086d0000A36Dsv00001028sd0000085Cbc0Csc03i30",
+        "label": "Onboard - Other"
+      }
+    ]
+  },
+  "smbios": {
+    "bios": {
+      "handle": 0,
+      "vendor": "Dell Inc.",
+      "version": "1.4.2",
+      "date": "06/11/2019",
+      "features": [
+        "PCI supported",
+        "PnP supported",
+        "BIOS flashable",
+        "BIOS shadowing allowed",
+        "CD boot supported",
+        "Selectable boot supported",
+        "EDD spec supported",
+        "1.2MB Floppy supported",
+        "720kB Floppy supported",
+        "2.88MB Floppy supported",
+        "Print Screen supported",
+        "8042 Keyboard Services supported",
+        "Serial Services supported",
+        "Printer Services supported",
+        "ACPI supported",
+        "USB Legacy supported",
+        "BIOS Boot Spec supported",
+        "F12 Network boot supported"
+      ],
+      "start_address": "0xf0000",
+      "rom_size": 16777216
+    },
+    "board": {
+      "handle": 2,
+      "manufacturer": "Dell Inc.",
+      "product": "03KWTV",
+      "version": "A02",
+      "board_type": {
+        "hex": "000a",
+        "name": "Motherboard",
+        "value": 10
+      },
+      "features": [
+        "Hosting Board",
+        "Replaceable"
+      ],
+      "location": "",
+      "chassis": 3
+    },
+    "cache": [
+      {
+        "handle": 18,
+        "socket": "L1 Cache",
+        "size_max": 384,
+        "size_current": 384,
+        "speed": 0,
+        "mode": {
+          "hex": "0001",
+          "name": "Write Back",
+          "value": 1
+        },
+        "enabled": true,
+        "location": {
+          "hex": "0000",
+          "name": "Internal",
+          "value": 0
+        },
+        "socketed": false,
+        "level": 0,
+        "ecc": {
+          "hex": "0004",
+          "name": "Parity",
+          "value": 4
+        },
+        "cache_type": {
+          "hex": "0005",
+          "name": "Unified",
+          "value": 5
+        },
+        "associativity": {
+          "hex": "0007",
+          "name": "8-way Set-Associative",
+          "value": 7
+        },
+        "sram_type_current": [
+          "Synchronous"
+        ],
+        "sram_type_supported": [
+          "Synchronous"
+        ]
+      },
+      {
+        "handle": 19,
+        "socket": "L2 Cache",
+        "size_max": 1536,
+        "size_current": 1536,
+        "speed": 0,
+        "mode": {
+          "hex": "0001",
+          "name": "Write Back",
+          "value": 1
+        },
+        "enabled": true,
+        "location": {
+          "hex": "0000",
+          "name": "Internal",
+          "value": 0
+        },
+        "socketed": false,
+        "level": 1,
+        "ecc": {
+          "hex": "0005",
+          "name": "Single-bit",
+          "value": 5
+        },
+        "cache_type": {
+          "hex": "0005",
+          "name": "Unified",
+          "value": 5
+        },
+        "associativity": {
+          "hex": "0005",
+          "name": "4-way Set-Associative",
+          "value": 5
+        },
+        "sram_type_current": [
+          "Synchronous"
+        ],
+        "sram_type_supported": [
+          "Synchronous"
+        ]
+      },
+      {
+        "handle": 20,
+        "socket": "L3 Cache",
+        "size_max": 9216,
+        "size_current": 9216,
+        "speed": 0,
+        "mode": {
+          "hex": "0001",
+          "name": "Write Back",
+          "value": 1
+        },
+        "enabled": true,
+        "location": {
+          "hex": "0000",
+          "name": "Internal",
+          "value": 0
+        },
+        "socketed": false,
+        "level": 2,
+        "ecc": {
+          "hex": "0006",
+          "name": "Multi-bit",
+          "value": 6
+        },
+        "cache_type": {
+          "hex": "0005",
+          "name": "Unified",
+          "value": 5
+        },
+        "associativity": {
+          "hex": "0009",
+          "name": "Other",
+          "value": 9
+        },
+        "sram_type_current": [
+          "Synchronous"
+        ],
+        "sram_type_supported": [
+          "Synchronous"
+        ]
+      }
+    ],
+    "chassis": [
+      {
+        "handle": 3,
+        "manufacturer": "Dell Inc.",
+        "version": "",
+        "chassis_type": {
+          "hex": "0003",
+          "name": "Desktop",
+          "value": 3
+        },
+        "lock_present": false,
+        "bootup_state": {
+          "hex": "0003",
+          "name": "Safe",
+          "value": 3
+        },
+        "power_state": {
+          "hex": "0003",
+          "name": "Safe",
+          "value": 3
+        },
+        "thermal_state": {
+          "hex": "0003",
+          "name": "Safe",
+          "value": 3
+        },
+        "security_state": {
+          "hex": "0003",
+          "name": "None",
+          "value": 3
+        },
+        "oem": "0x0"
+      }
+    ],
+    "config": {
+      "handle": 5,
+      "options": [
+        "Default string"
+      ]
+    },
+    "group_associations": [
+      {
+        "handle": 61505,
+        "name": "Firmware Version Info",
+        "handles": [
+          60129542157,
+          64424509454,
+          68719476751,
+          73014444048,
+          264114718900241,
+          158913851446
+        ]
+      },
+      {
+        "handle": 61507,
+        "name": "$MEI",
+        "handles": [
+          0
+        ]
+      }
+    ],
+    "language": [
+      {
+        "handle": 61506,
+        "languages": [
+          "en|US|iso8859-1"
+        ]
+      }
+    ],
+    "memory_array": [
+      {
+        "handle": 9,
+        "location": {
+          "hex": "0003",
+          "name": "Motherboard",
+          "value": 3
+        },
+        "usage": {
+          "hex": "0003",
+          "name": "System memory",
+          "value": 3
+        },
+        "ecc": {
+          "hex": "0003",
+          "name": "None",
+          "value": 3
+        },
+        "max_size": "0x2000000",
+        "error_handle": 65534,
+        "slots": 2
+      }
+    ],
+    "memory_array_mapped_address": [
+      {
+        "handle": 12,
+        "array_handle": 9,
+        "start_address": "0x0",
+        "end_address": "0x800000000",
+        "part_width": 2
+      }
+    ],
+    "memory_device": [
+      {
+        "handle": 10,
+        "location": "DIMM1",
+        "bank_location": "",
+        "manufacturer": "0080000080AD",
+        "part_number": "INTECKO DDR4 16GB",
+        "array_handle": 9,
+        "error_handle": 65534,
+        "width": 64,
+        "ecc_bits": 0,
+        "size": 16777216,
+        "form_factor": {
+          "hex": "000d",
+          "name": "SODIMM",
+          "value": 13
+        },
+        "set": 0,
+        "memory_type": {
+          "hex": "001a",
+          "name": "Other",
+          "value": 26
+        },
+        "memory_type_details": [
+          "Synchronous"
+        ],
+        "speed": 2666
+      },
+      {
+        "handle": 11,
+        "location": "DIMM2",
+        "bank_location": "",
+        "manufacturer": "80AD000080AD",
+        "part_number": "HMA82GS6CJR8N-VK",
+        "array_handle": 9,
+        "error_handle": 65534,
+        "width": 64,
+        "ecc_bits": 0,
+        "size": 16777216,
+        "form_factor": {
+          "hex": "000d",
+          "name": "SODIMM",
+          "value": 13
+        },
+        "set": 0,
+        "memory_type": {
+          "hex": "001a",
+          "name": "Other",
+          "value": 26
+        },
+        "memory_type_details": [
+          "Synchronous"
+        ],
+        "speed": 2666
+      }
+    ],
+    "memory_device_mapped_address": [
+      {
+        "handle": 40,
+        "memory_device_handle": 10,
+        "array_map_handle": 12,
+        "start_address": "0x400000000",
+        "end_address": "0x800000000",
+        "row_position": 1,
+        "interleave_position": 2,
+        "interleave_depth": 1
+      },
+      {
+        "handle": 41,
+        "memory_device_handle": 11,
+        "array_map_handle": 12,
+        "start_address": "0x0",
+        "end_address": "0x400000000",
+        "row_position": 1,
+        "interleave_position": 1,
+        "interleave_depth": 1
+      }
+    ],
+    "port_connector": [
+      {
+        "handle": 22,
+        "port_type": {
+          "hex": "001f",
+          "name": "Network Port",
+          "value": 31
+        },
+        "external_connector_type": {
+          "hex": "000b",
+          "name": "RJ-45",
+          "value": 11
+        },
+        "external_reference_designator": "LAN"
+      },
+      {
+        "handle": 23,
+        "port_type": {
+          "hex": "001c",
+          "name": "Video Port",
+          "value": 28
+        },
+        "external_connector_type": {
+          "hex": "00ff",
+          "name": "Other",
+          "value": 255
+        },
+        "external_reference_designator": "DisplayPort 1"
+      },
+      {
+        "handle": 24,
+        "port_type": {
+          "hex": "001c",
+          "name": "Video Port",
+          "value": 28
+        },
+        "external_connector_type": {
+          "hex": "00ff",
+          "name": "Other",
+          "value": 255
+        },
+        "external_reference_designator": "HDMI"
+      },
+      {
+        "handle": 25,
+        "port_type": {
+          "hex": "0010",
+          "name": "USB",
+          "value": 16
+        },
+        "external_connector_type": {
+          "hex": "0012",
+          "name": "Access Bus [USB]",
+          "value": 18
+        },
+        "external_reference_designator": "Rear USB 3.0"
+      },
+      {
+        "handle": 26,
+        "port_type": {
+          "hex": "0010",
+          "name": "USB",
+          "value": 16
+        },
+        "external_connector_type": {
+          "hex": "0012",
+          "name": "Access Bus [USB]",
+          "value": 18
+        },
+        "external_reference_designator": "Rear USB 3.0"
+      },
+      {
+        "handle": 27,
+        "port_type": {
+          "hex": "0010",
+          "name": "USB",
+          "value": 16
+        },
+        "external_connector_type": {
+          "hex": "0012",
+          "name": "Access Bus [USB]",
+          "value": 18
+        },
+        "external_reference_designator": "Rear USB 2.0"
+      },
+      {
+        "handle": 28,
+        "port_type": {
+          "hex": "0010",
+          "name": "USB",
+          "value": 16
+        },
+        "external_connector_type": {
+          "hex": "0012",
+          "name": "Access Bus [USB]",
+          "value": 18
+        },
+        "external_reference_designator": "Rear USB 2.0"
+      },
+      {
+        "handle": 29,
+        "port_type": {
+          "hex": "0020",
+          "name": "Other",
+          "value": 32
+        },
+        "internal_connector_type": {
+          "hex": "0022",
+          "name": "Other",
+          "value": 34
+        },
+        "internal_reference_designator": "SATA0"
+      },
+      {
+        "handle": 30,
+        "port_type": {
+          "hex": "00ff",
+          "name": "Other",
+          "value": 255
+        },
+        "internal_connector_type": {
+          "hex": "00ff",
+          "name": "Other",
+          "value": 255
+        },
+        "internal_reference_designator": "FAN_CPU"
+      },
+      {
+        "handle": 31,
+        "port_type": {
+          "hex": "00ff",
+          "name": "Other",
+          "value": 255
+        },
+        "internal_connector_type": {
+          "hex": "00ff",
+          "name": "Other",
+          "value": 255
+        },
+        "internal_reference_designator": "INTRUDER"
+      },
+      {
+        "handle": 32,
+        "port_type": {
+          "hex": "00ff",
+          "name": "Other",
+          "value": 255
+        },
+        "internal_connector_type": {
+          "hex": "00ff",
+          "name": "Other",
+          "value": 255
+        },
+        "internal_reference_designator": "INT_SPKR"
+      },
+      {
+        "handle": 33,
+        "port_type": {
+          "hex": "00ff",
+          "name": "Other",
+          "value": 255
+        },
+        "internal_connector_type": {
+          "hex": "00ff",
+          "name": "Other",
+          "value": 255
+        },
+        "internal_reference_designator": "THRM_2"
+      },
+      {
+        "handle": 34,
+        "port_type": {
+          "hex": "001d",
+          "name": "Audio Port",
+          "value": 29
+        },
+        "internal_connector_type": {
+          "hex": "00ff",
+          "name": "Other",
+          "value": 255
+        },
+        "internal_reference_designator": "FRONTPANEL",
+        "external_connector_type": {
+          "hex": "001f",
+          "name": "Mini-jack [headphones]",
+          "value": 31
+        },
+        "external_reference_designator": "Microphone"
+      },
+      {
+        "handle": 35,
+        "port_type": {
+          "hex": "001d",
+          "name": "Audio Port",
+          "value": 29
+        },
+        "internal_connector_type": {
+          "hex": "00ff",
+          "name": "Other",
+          "value": 255
+        },
+        "internal_reference_designator": "FRONTPANEL",
+        "external_connector_type": {
+          "hex": "001f",
+          "name": "Mini-jack [headphones]",
+          "value": 31
+        },
+        "external_reference_designator": "Headphone"
+      },
+      {
+        "handle": 36,
+        "port_type": {
+          "hex": "0010",
+          "name": "USB",
+          "value": 16
+        },
+        "internal_connector_type": {
+          "hex": "00ff",
+          "name": "Other",
+          "value": 255
+        },
+        "internal_reference_designator": "FRONTPANEL",
+        "external_connector_type": {
+          "hex": "0012",
+          "name": "Access Bus [USB]",
+          "value": 18
+        },
+        "external_reference_designator": "Front USB 3.0"
+      },
+      {
+        "handle": 37,
+        "port_type": {
+          "hex": "0010",
+          "name": "USB",
+          "value": 16
+        },
+        "internal_connector_type": {
+          "hex": "00ff",
+          "name": "Other",
+          "value": 255
+        },
+        "internal_reference_designator": "FRONTPANEL",
+        "external_connector_type": {
+          "hex": "0012",
+          "name": "Access Bus [USB]",
+          "value": 18
+        },
+        "external_reference_designator": "Front USB 3.0"
+      }
+    ],
+    "power_controls": [
+      {
+        "handle": 7,
+        "month": 0,
+        "day": 0,
+        "hour": 0,
+        "minute": 0,
+        "second": 0
+      }
+    ],
+    "processor": [
+      {
+        "handle": 21,
+        "socket": "U3E1",
+        "socket_type": {
+          "hex": "0032",
+          "name": "Other",
+          "value": 50
+        },
+        "socket_populated": true,
+        "manufacturer": "Intel(R) Corporation",
+        "version": "Intel(R) Core(TM) i5-8500T CPU @ 2.10GHz",
+        "part": "",
+        "processor_type": {
+          "hex": "0003",
+          "name": "CPU",
+          "value": 3
+        },
+        "processor_family": {
+          "hex": "00cd",
+          "name": "Other",
+          "value": 205
+        },
+        "processor_status": {
+          "hex": "0001",
+          "name": "Enabled",
+          "value": 1
+        },
+        "clock_ext": 100,
+        "clock_max": 4200,
+        "cache_handle_l1": 18,
+        "cache_handle_l2": 19,
+        "cache_handle_l3": 20
+      }
+    ],
+    "slot": [
+      {
+        "handle": 38,
+        "designation": "SLOT1_M.2",
+        "slot_type": {
+          "hex": "0017",
+          "name": "Other",
+          "value": 23
+        },
+        "bus_width": {
+          "hex": "000a",
+          "name": "Other",
+          "value": 10
+        },
+        "usage": {
+          "hex": "0004",
+          "name": "In Use",
+          "value": 4
+        },
+        "length": {
+          "hex": "0004",
+          "name": "Long",
+          "value": 4
+        },
+        "id": 1,
+        "features": [
+          "3.3 V",
+          "PME#"
+        ]
+      },
+      {
+        "handle": 39,
+        "designation": "SLOT2_M.2",
+        "slot_type": {
+          "hex": "0015",
+          "name": "Other",
+          "value": 21
+        },
+        "bus_width": {
+          "hex": "0008",
+          "name": "Other",
+          "value": 8
+        },
+        "usage": {
+          "hex": "0003",
+          "name": "Available",
+          "value": 3
+        },
+        "length": {
+          "hex": "0003",
+          "name": "Short",
+          "value": 3
+        },
+        "id": 2,
+        "features": [
+          "3.3 V",
+          "PME#"
+        ]
+      }
+    ],
+    "system": {
+      "handle": 1,
+      "manufacturer": "Dell Inc.",
+      "product": "OptiPlex 3060",
+      "version": "",
+      "wake_up": {
+        "hex": "0006",
+        "name": "Power Switch",
+        "value": 6
+      }
+    }
+  }
+}

--- a/hosts/iroh/hardware.nix
+++ b/hosts/iroh/hardware.nix
@@ -5,17 +5,14 @@
   modulesPath,
   ...
 }: {
-  services.qemuGuest.enable = true;
-
   boot = {
     initrd.availableKernelModules = [
-      "virtio_pci"
-      "virtio_blk"
-      "virtio_scsi"
       "ahci"
       "xhci_pci"
       "usbhid"
-      "sr_mod"
+      "usb_storage"
+      "sd_mod" # instead of virtio_blk/virtio_scsi
+      "nvme"
     ];
     supportedFilesystems = [
       "btrfs"
@@ -24,6 +21,7 @@
   };
 
   hardware = {
+    cpu.intel.updateMicrocode = true;
     usbStorage.manageShutdown = true;
     graphics = {
       enable = true;
@@ -47,7 +45,7 @@
       interval = "monthly";
     };
     udev.extraRules = ''
-      ACTION=="add|change", KERNEL=="sdc", ATTR{queue/scheduler}="bfq"
+      ACTION=="add|change", KERNEL=="sd[a-z]", ATTR{queue/rotational}=="1", ATTR{queue/scheduler}="bfq""
     '';
   };
 
@@ -56,7 +54,6 @@
   imports = [
     inputs.disko.nixosModules.disko
     ./disko.nix
-    (modulesPath + "/profiles/qemu-guest.nix")
   ];
 
   home-manager.users.${username} = _: {

--- a/hosts/iroh/hardware.nix
+++ b/hosts/iroh/hardware.nix
@@ -2,6 +2,7 @@
   pkgs,
   inputs,
   username,
+  lib,
   ...
 }: {
   boot = {

--- a/hosts/iroh/hardware.nix
+++ b/hosts/iroh/hardware.nix
@@ -2,7 +2,6 @@
   pkgs,
   inputs,
   username,
-  modulesPath,
   ...
 }: {
   boot = {

--- a/hosts/iroh/hardware.nix
+++ b/hosts/iroh/hardware.nix
@@ -51,7 +51,7 @@
     '';
   };
 
-  system.stateVersion = "26.05";
+  system.stateVersion = "26.11";
 
   imports = [
     inputs.disko.nixosModules.disko
@@ -60,6 +60,6 @@
   ];
 
   home-manager.users.${username} = _: {
-    home.stateVersion = "26.05";
+    home.stateVersion = "26.11";
   };
 }

--- a/hosts/iroh/hardware.nix
+++ b/hosts/iroh/hardware.nix
@@ -10,7 +10,7 @@
       "xhci_pci"
       "usbhid"
       "usb_storage"
-      "sd_mod" # instead of virtio_blk/virtio_scsi
+      "sd_mod"
       "nvme"
     ];
     supportedFilesystems = [
@@ -20,6 +20,9 @@
   };
 
   hardware = {
+    facter = lib.optionalAttrs (builtins.pathExists ./facter.json) {
+      reportPath = ./facter.json;
+    };
     cpu.intel.updateMicrocode = true;
     usbStorage.manageShutdown = true;
     graphics = {

--- a/hosts/iroh/hardware.nix
+++ b/hosts/iroh/hardware.nix
@@ -48,7 +48,7 @@
       interval = "monthly";
     };
     udev.extraRules = ''
-      ACTION=="add|change", KERNEL=="sd[a-z]", ATTR{queue/rotational}=="1", ATTR{queue/scheduler}="bfq""
+      ACTION=="add|change", KERNEL=="sd[a-z]", ATTR{queue/rotational}=="1", ATTR{queue/scheduler}="bfq"
     '';
   };
 

--- a/modules/services/README.md
+++ b/modules/services/README.md
@@ -6,6 +6,12 @@ PERSONAL
 
 - Sets up a NAS server
 
+## nixosModules.nas-client
+
+PERSONAL
+
+- Sets up a NAS client for above server
+
 ## nixosModules.secrets
 
 - Sets up secrets management system with sops.
@@ -28,7 +34,7 @@ DON'T USE ON PRODUCTION MACHINES
 
 - Sets up SSH with my public keys.
 - Installs Lazyssh.
-- Puts publically available SSH public and private keys to right directories (now with persist, so they work with impermanence) with sops.
+- Puts publically available SSH public and private keys to right directories.
 
 ## nixosModules.ssh-debug
 

--- a/modules/services/README.md
+++ b/modules/services/README.md
@@ -1,5 +1,11 @@
 # Services
 
+## nixosModules.nas-server
+
+PERSONAL
+
+- Sets up a NAS server
+
 ## nixosModules.secrets
 
 - Sets up secrets management system with sops.

--- a/modules/services/home-server.nix
+++ b/modules/services/home-server.nix
@@ -1,12 +1,7 @@
-{
-  inputs,
-  self,
-  ...
-}: {
+{self, ...}: {
   flake = {
     nixosModules.home-server-iroh = {
       lib,
-      username,
       impermanence,
       config,
       pkgs,

--- a/modules/services/home-server.nix
+++ b/modules/services/home-server.nix
@@ -19,8 +19,9 @@
       imports =
         [
           # self.nixosModules.web-expose already imported via ai-services
+          self.nixosModules.web-expose
           inputs.nixflix.nixosModules.default
-          self.nixosModules.ai-services
+          # self.nixosModules.ai-services
         ]
         ++ lib.optional impermanence {
           environment.persistence."/persist" = {
@@ -159,6 +160,8 @@
         "aria2/rpc-token" = {
           owner = "aria2";
         };
+
+        "fgc/env" = {};
       };
 
       custom.web-expose = {
@@ -381,6 +384,7 @@
         backend = "podman";
         containers = {
           freshrss = {
+            # renovate: versioning=docker
             image = "ghcr.io/freshrss/freshrss:1.29.1";
 
             environment = {
@@ -426,6 +430,7 @@
           };
 
           up-snap = {
+            # renovate: versioning=docker
             image = "ghcr.io/seriousm4x/upsnap:5.4.1";
             environment = {
               TZ = "Europe/Warsaw";
@@ -447,9 +452,9 @@
             autoStart = true;
 
             ports = [
-              "8585:8585"
-              "6881:6881"
-              "6881:6881/udp"
+              "127.0.0.1:8585:8585"
+              "127.0.0.1:6881:6881"
+              "127.0.0.1:6881:6881/udp"
             ];
 
             environment = {
@@ -462,6 +467,20 @@
             volumes = [
               "/var/lib/qbittorrent/config:/config"
               "/mnt/storage/qbittorrent/downloads:/downloads"
+            ];
+          };
+
+          free-games = {
+            # renovate: versioning=docker
+            image = "ghcr.io/feldorn/free-games-claimer:a7d40b2";
+            autoStart = true;
+            ports = [
+              "127.0.0.1:6080:6080"
+              "127.0.0.1:7080:7080"
+            ];
+            volumes = ["/var/lib/fgc:/fgc/data"];
+            environmentFiles = [
+              config.sops.secrets."fgc/env".path
             ];
           };
         };

--- a/modules/services/home-server.nix
+++ b/modules/services/home-server.nix
@@ -287,6 +287,13 @@
             subjects = ["group:service-users"];
             traefikRule = ''Host(`fgc.${cfg.domain}`) && (PathPrefix(`/novnc`) || Path(`/websockify`))'';
           };
+
+          aiostreams = {
+            subdomain = "aiostreams";
+            port = 4321;
+            public = true;
+            auth = "bypass";
+          };
         };
       };
 

--- a/modules/services/home-server.nix
+++ b/modules/services/home-server.nix
@@ -396,7 +396,7 @@
               "127.0.0.1:7080:7080"
             ];
             environment = {
-                PUBLIC_URL = "https://fgc.${config.custom.web-expose.domain}";
+              PUBLIC_URL = "https://fgc.${config.custom.web-expose.domain}";
             };
             volumes = ["/var/lib/fgc:/fgc/data"];
             environmentFiles = [

--- a/modules/services/home-server.nix
+++ b/modules/services/home-server.nix
@@ -274,7 +274,7 @@
             subjects = ["group:service-users"];
           };
 
-          fgc-novnc = {
+          fgcNovnc = {
             subdomain = "fgc-novnc";
             port = 6080;
             public = false;
@@ -382,7 +382,7 @@
             ];
           };
 
-          free-games = {
+          freeGames = {
             # renovate: versioning=docker
             image = "ghcr.io/feldorn/free-games-claimer:a7d40b2";
             autoStart = true;

--- a/modules/services/home-server.nix
+++ b/modules/services/home-server.nix
@@ -285,7 +285,7 @@
             public = false;
             auth = "two_factor";
             subjects = ["group:service-users"];
-            traefikRule = ''Host(`fgc.${cfg.domain}`) && (PathPrefix(`/novnc`) || Path(`/websockify`))'';
+            traefikRule = ''Host(`fgc.${domain}`) && (PathPrefix(`/novnc`) || Path(`/websockify`))'';
           };
 
           aiostreams = {

--- a/modules/services/home-server.nix
+++ b/modules/services/home-server.nix
@@ -101,6 +101,8 @@
         };
 
         "fgc/env" = {};
+
+        "aiostreams/env" = {};
       };
 
       custom.web-expose = {
@@ -268,6 +270,23 @@
             auth = "two_factor";
             subjects = ["group:service-users"];
           };
+
+          fgc = {
+            subdomain = "fgc";
+            port = 7080;
+            public = false;
+            auth = "two_factor";
+            subjects = ["group:service-users"];
+          };
+
+          fgc-novnc = {
+            subdomain = "fgc-novnc";
+            port = 6080;
+            public = false;
+            auth = "two_factor";
+            subjects = ["group:service-users"];
+            traefikRule = ''Host(`fgc.${cfg.domain}`) && (PathPrefix(`/novnc`) || Path(`/websockify`))'';
+          };
         };
       };
 
@@ -369,10 +388,29 @@
               "127.0.0.1:6080:6080"
               "127.0.0.1:7080:7080"
             ];
+            environment = {
+                PUBLIC_URL = "https://fgc.${config.custom.web-expose.domain}";
+            };
             volumes = ["/var/lib/fgc:/fgc/data"];
             environmentFiles = [
               config.sops.secrets."fgc/env".path
             ];
+          };
+
+          aiostreams = {
+            # renovate: versioning=docker
+            image = "ghcr.io/viren070/aiostreams:v2.30.3";
+            ports = ["127.0.0.1:4321:3000"];
+            volumes = [
+              "/var/lib/aiostreams/data:/app/data"
+            ];
+            environment = {
+              BASE_URL = "https://aiostreams.${domain}";
+            };
+            environmentFiles = [
+              config.sops.secrets."aiostreams/env".path
+            ];
+            autoStart = true;
           };
         };
       };

--- a/modules/services/home-server.nix
+++ b/modules/services/home-server.nix
@@ -18,9 +18,8 @@
     in {
       imports =
         [
-          # self.nixosModules.web-expose already imported via ai-services
           self.nixosModules.web-expose
-          inputs.nixflix.nixosModules.default
+          # self.nixosModules.nixflix
           # self.nixosModules.ai-services
         ]
         ++ lib.optional impermanence {
@@ -30,67 +29,6 @@
         };
 
       sops.secrets = {
-        "nixflix/sonarr/api-key" = {
-          owner = "sonarr";
-        };
-        "nixflix/sonarr/password" = {
-          owner = "sonarr";
-        };
-
-        "nixflix/radarr/api-key" = {
-          owner = "radarr";
-        };
-        "nixflix/radarr/password" = {
-          owner = "radarr";
-        };
-
-        "nixflix/prowlarr/api-key" = {
-          owner = "prowlarr";
-        };
-        "nixflix/prowlarr/password" = {
-          owner = "prowlarr";
-        };
-
-        "nixflix/seerr/api-key" = {
-          owner = "seerr";
-        };
-        "nixflix/seerr/jellyfin-admin-password" = {
-          owner = "seerr";
-        };
-
-        "nixflix/jellyfin/users/admin-password" = {
-          owner = "jellyfin";
-        };
-        "nixflix/jellyfin/users/user1-password" = {
-          owner = "jellyfin";
-        };
-        "nixflix/jellyfin/users/user2-password" = {
-          owner = "jellyfin";
-        };
-        "nixflix/jellyfin/api-key" = {
-          owner = "jellyfin";
-        };
-
-        "nixflix/qbittorrent/password" = {
-          owner = "qbittorrent";
-        };
-
-        "nixflix/opensubtitles-com/password" = {
-          owner = "jellyfin";
-        };
-
-        "nixflix/opensubtitles-com/api-key" = {
-          owner = "jellyfin";
-        };
-
-        "nixflix/subdl/api-key" = {
-          owner = "jellyfin";
-        };
-
-        "nixflix/subsource/api-key" = {
-          owner = "jellyfin";
-        };
-
         "routing/traefik/env" = {
           owner = "traefik";
         };
@@ -139,6 +77,7 @@
           owner = "authelia-main";
         };
         "freshrss/oidc-env" = {};
+
         "filebrowser/env" = {};
         "filebrowser/oidc-client-secret-hash" = {
           owner = "authelia-main";
@@ -223,54 +162,6 @@
             public = true;
             auth = "two_factor";
             subjects = ["group:service-users"];
-          };
-
-          jellyfin = {
-            subdomain = "jellyfin";
-            port = 8096;
-            host = "127.0.0.1";
-            public = true;
-            auth = null;
-          };
-
-          sonarr = {
-            subdomain = "sonarr";
-            port = 8989;
-            host = "127.0.0.1";
-            public = false;
-            auth = null;
-          };
-
-          radarr = {
-            subdomain = "radarr";
-            port = 7878;
-            host = "127.0.0.1";
-            public = false;
-            auth = null;
-          };
-
-          prowlarr = {
-            subdomain = "prowlarr";
-            port = 9696;
-            host = "127.0.0.1";
-            public = false;
-            auth = null;
-          };
-
-          seerr = {
-            subdomain = "seerr";
-            port = 5055;
-            host = "127.0.0.1";
-            public = false;
-            auth = null;
-          };
-
-          qbittorrent-nixflix = {
-            subdomain = "qbittorrent-nixflix";
-            port = 8282;
-            host = "127.0.0.1";
-            public = false;
-            auth = null;
           };
 
           freshrss = {
@@ -666,281 +557,6 @@
         #};
       };
 
-      nixflix = {
-        enable = true;
-
-        mediaDir = "/mnt/data/media";
-        downloadsDir = "/mnt/data/downloads";
-        stateDir = "/var/lib";
-        mediaUsers = [username];
-
-        nginx.enable = false;
-        caddy.enable = false;
-
-        postgres.enable = true;
-
-        theme.enable = true;
-
-        sonarr = {
-          enable = true;
-          openFirewall = true;
-
-          config = {
-            apiKey = {
-              _secret = config.sops.secrets."nixflix/sonarr/api-key".path;
-            };
-            hostConfig = {
-              username = "admin";
-              password = {
-                _secret = config.sops.secrets."nixflix/sonarr/password".path;
-              };
-              authenticationMethod = "forms";
-              authenticationRequired = "disabledForLocalAddresses";
-            };
-          };
-        };
-
-        radarr = {
-          enable = true;
-          openFirewall = true;
-
-          config = {
-            apiKey = {
-              _secret = config.sops.secrets."nixflix/radarr/api-key".path;
-            };
-            hostConfig = {
-              username = "admin";
-              password = {
-                _secret = config.sops.secrets."nixflix/radarr/password".path;
-              };
-              authenticationMethod = "forms";
-              authenticationRequired = "disabledForLocalAddresses";
-            };
-          };
-        };
-
-        prowlarr = {
-          enable = true;
-          openFirewall = true;
-
-          config = {
-            apiKey = {
-              _secret = config.sops.secrets."nixflix/prowlarr/api-key".path;
-            };
-            indexers = [
-              {
-                name = "1337x";
-                tags = ["flaresolverr"];
-              }
-              {name = "Nyaa";}
-              {
-                name = "TorrentGalaxy";
-                tags = ["flaresolverr"];
-              }
-              {
-                name = "The Pirate Bay";
-                tags = ["flaresolverr"];
-              }
-              {name = "EZTV";}
-              {name = "LimeTorrents";}
-            ];
-            hostConfig = {
-              username = "admin";
-              password = {
-                _secret = config.sops.secrets."nixflix/prowlarr/password".path;
-              };
-              authenticationMethod = "forms";
-              authenticationRequired = "disabledForLocalAddresses";
-            };
-          };
-        };
-
-        jellyfin = {
-          enable = true;
-          openFirewall = true;
-
-          apiKey = {
-            _secret = config.sops.secrets."nixflix/jellyfin/api-key".path;
-          };
-
-          cacheDir = "/var/cache/jellyfin";
-
-          encoding = {
-            enableHardwareEncoding = true;
-            hardwareAccelerationType = "qsv";
-            qsvDevice = "/dev/dri/renderD128";
-            hardwareDecodingCodecs = [
-              "h264"
-              "hevc"
-              "mpeg2video"
-              "vc1"
-              "vp8"
-              "vp9"
-            ];
-            transcodingTempPath = "/var/cache/jellyfin/transcodes";
-            enableSubtitleExtraction = true;
-            enableIntelLowPowerH264HwEncoder = false;
-            enableIntelLowPowerHevcHwEncoder = false;
-          };
-
-          system = {
-            enableLegacyAuthorization = false;
-            serverName = config.networking.hostName;
-            cacheSize = 4096;
-          };
-
-          libraries = let
-            subtitleSettings = {
-              subtitleFetcherOrder = [
-                "subbuzz"
-                "Open Subtitles"
-              ];
-              subtitleDownloadLanguages = [
-                "eng"
-                "pl"
-              ];
-              saveSubtitlesWithMedia = true;
-              allowEmbeddedSubtitles = "AllowAll";
-              requirePerfectSubtitleMatch = false;
-              skipSubtitlesIfAudioTrackMatches = false;
-              skipSubtitlesIfEmbeddedSubtitlesPresent = true;
-            };
-          in {
-            Shows = subtitleSettings;
-            Movies = subtitleSettings;
-          };
-
-          plugins = {
-            subbuzz = {
-              enable = true;
-              config = {
-                OpenSubUserName = "surface";
-                OpenSubPassword._secret = config.sops.secrets."nixflix/opensubtitles-com/password".path;
-                OpenSubApiKey._secret = config.sops.secrets."nixflix/opensubtitles-com/api-key".path;
-                EnableOpenSubtitles = true;
-                EnableYifySubtitles = true;
-                EnablePodnapisiNet = true;
-                EnableSubSource = true;
-                SubSourceApiKey._secret = config.sops.secrets."nixflix/subsource/api-key".path;
-                EnableSubdlCom = true;
-                SubdlApiKey._secret = config.sops.secrets."nixflix/subdl/api-key".path;
-              };
-            };
-
-            "Open Subtitles" = {
-              enable = true;
-              config = {
-                Username = "surface";
-                Password._secret = config.sops.secrets."nixflix/opensubtitles-com/password".path;
-              };
-            };
-            "Subtitle Extract" = {
-              enable = true;
-              config.ExtractionDuringLibraryScan = true;
-            };
-          };
-
-          users = {
-            admin = {
-              password = {
-                _secret = config.sops.secrets."nixflix/jellyfin/users/admin-password".path;
-              };
-              policy = {
-                isAdministrator = true;
-                enableContentDeletion = true;
-                enableSubtitleManagement = true;
-              };
-              configuration = {
-                subtitleMode = "Smart";
-                enableNextEpisodeAutoPlay = true;
-              };
-              mutable = false;
-            };
-            user1 = {
-              password = {
-                _secret = config.sops.secrets."nixflix/jellyfin/users/user1-password".path;
-              };
-              policy = {
-                isAdministrator = false;
-                enableContentDeletion = false;
-                enableSubtitleManagement = false;
-              };
-              configuration = {
-                subtitleMode = "Smart";
-                enableNextEpisodeAutoPlay = true;
-              };
-              mutable = false;
-            };
-            user2 = {
-              password = {
-                _secret = config.sops.secrets."nixflix/jellyfin/users/user2-password".path;
-              };
-              policy = {
-                isAdministrator = false;
-                enableContentDeletion = false;
-                enableSubtitleManagement = false;
-              };
-              configuration = {
-                subtitleMode = "Smart";
-                enableNextEpisodeAutoPlay = true;
-              };
-              mutable = false;
-            };
-          };
-        };
-
-        seerr = {
-          enable = true;
-          openFirewall = true;
-          port = 5055;
-
-          apiKey = {
-            _secret = config.sops.secrets."nixflix/seerr/api-key".path;
-          };
-        };
-
-        torrentClients.qbittorrent = {
-          enable = true;
-          webuiPort = 8282;
-
-          password = {
-            _secret = config.sops.secrets."nixflix/qbittorrent/password".path;
-          };
-        };
-
-        flaresolverr = {
-          enable = true;
-          port = 8191;
-        };
-
-        recyclarr = {
-          enable = true;
-          radarrQuality = "1080p";
-          sonarrQuality = "1080p";
-          cleanupUnmanagedProfiles = {
-            enable = true;
-          };
-        };
-
-        downloadarr = {
-          enable = true;
-        };
-      };
-
-      hardware.graphics = {
-        enable = true;
-        extraPackages = with pkgs; [
-          intel-media-driver
-          intel-vaapi-driver
-          libvdpau-va-gl
-        ];
-      };
-
-      users.users.jellyfin.extraGroups = [
-        "video"
-        "render"
-      ];
-
       systemd = {
         tmpfiles.rules = [
           "d /var/lib/freshrss/data       0750 root root -"
@@ -950,16 +566,6 @@
           "d /mnt/storage/aria2 0755 aria2 aria2 - -"
           "d /mnt/storage/aria2/downloads 0755 aria2 aria2 - -"
           "d /var/lib/qbittorrent/config 0755 1000 1000 -"
-        ];
-        mounts = [
-          {
-            what = "tmpfs";
-            where = "/var/cache/jellyfin";
-            type = "tmpfs";
-            options = "size=4G,mode=0755,uid=146,gid=146";
-            before = ["jellyfin.service"];
-            wantedBy = ["multi-user.target"];
-          }
         ];
         services.duckdns-updater = {
           description = "Update DuckDNS IP";
@@ -983,6 +589,7 @@
           };
         };
       };
+
       environment.etc = {
         "filebrowser-config.yaml".text = ''
           server:
@@ -1010,11 +617,7 @@
       };
 
       networking.firewall = {
-        allowedTCPPorts = [6881];
-        allowedUDPPorts = [
-          41641
-          6881
-        ];
+        allowedUDPPorts = [41641];
         trustedInterfaces = ["tailscale0"];
       };
     };

--- a/modules/services/nas.nix
+++ b/modules/services/nas.nix
@@ -1,6 +1,6 @@
 {...}: {
   flake = {
-    nixosModules.nas-server = {
+    nixosModules.nasServer = {
       lib,
       username,
       impermanence,
@@ -30,7 +30,7 @@
         allowedUDPPorts = [ 111 2049 4045 4046 4047 ];
       };
     };
-    nixosModules.nas-client = {
+    nixosModules.nasClient = {
       lib,
       username,
       impermanence,

--- a/modules/services/nas.nix
+++ b/modules/services/nas.nix
@@ -44,18 +44,17 @@
           };
         };
 
-        boot.supportedFilesystems = [ "nfs"];
-        fileSystems."/mnt/storage" = {
-          device = "192.168.0.10:/mnt/storage";
-          fsType = "nfs";
-          options = [
-            "x-systemd-automount"
-            "noauto"
-            "x-systemd.idle-timeout=600"
-            "rw"
-          ];
-        };
-
+      boot.supportedFilesystems = ["nfs"];
+      fileSystems."/mnt/storage" = {
+        device = "192.168.0.10:/mnt/storage";
+        fsType = "nfs";
+        options = [
+          "x-systemd-automount"
+          "noauto"
+          "x-systemd.idle-timeout=600"
+          "rw"
+        ];
+      };
     };
   };
 }

--- a/modules/services/nas.nix
+++ b/modules/services/nas.nix
@@ -18,14 +18,16 @@
 
       services.nfs.server = {
         enable = true;
-        fixedPorts = true;
+        lockdPort  = 4045;
+          mountdPort = 4046;
+          statdPort  = 4047;
         exports = ''
           /mnt/storage  192.168.0.0/24(rw,sync,no_subtree_check,no_root_squash)
         '';
       };
       networking.firewall = {
-        allowedTCPPorts = [111 2049];
-        allowedUDPPorts = [111 2049];
+        allowedTCPPorts = [ 111 2049 4045 4046 4047 ];
+        allowedUDPPorts = [ 111 2049 4045 4046 4047 ];
       };
     };
     nixosModules.nas-client = {

--- a/modules/services/nas.nix
+++ b/modules/services/nas.nix
@@ -1,0 +1,61 @@
+{...}: {
+  flake = {
+    nixosModules.nas-server = {
+      lib,
+      username,
+      impermanence,
+      ...
+    }: {
+      imports =
+        []
+        ++ lib.optional impermanence {
+          environment.persistence."/persist" = {
+            directories = [
+              "/var/lib/nfs"
+            ];
+          };
+        };
+
+      services.nfs.server = {
+        enable = true;
+        fixedPorts = true;
+        exports = ''
+          /mnt/storage  192.168.0.0/24(rw,sync,no_subtree_check,no_root_squash)
+        '';
+      };
+      networking.firewall = {
+        allowedTCPPorts = [111 2049];
+        allowedUDPPorts = [111 2049];
+      };
+    };
+    nixosModules.nas-client = {
+      lib,
+      username,
+      impermanence,
+      ...
+    }: {
+      imports =
+        []
+        ++ lib.optional impermanence {
+          environment.persistence."/persist" = {
+            directories = [
+              "/var/lib/nfs"
+            ];
+          };
+        };
+
+        boot.supportedFilesystems = [ "nfs"];
+        fileSystems."/mnt/storage" = {
+          device = "192.168.0.10:/mnt/storage";
+          fsType = "nfs";
+          options = [
+            "x-systemd-automount"
+            "noauto"
+            "x-systemd.idle-timeout=600"
+            "rw"
+          ];
+        };
+
+    };
+  };
+}

--- a/modules/services/nixflix.nix
+++ b/modules/services/nixflix.nix
@@ -1,0 +1,429 @@
+{
+  inputs,
+  self,
+  ...
+}: {
+  flake = {
+    nixosModules.nixflix = {
+      lib,
+      username,
+      config,
+      pkgs,
+      ...
+    }: let
+      domain = "iameasytoremember.duckdns.org";
+    in {
+      imports = [
+        inputs.nixflix.nixosModules.default
+        self.nixosModules.web-expose
+      ];
+
+      sops.secrets = {
+        "nixflix/sonarr/api-key" = {
+          owner = "sonarr";
+        };
+        "nixflix/sonarr/password" = {
+          owner = "sonarr";
+        };
+
+        "nixflix/radarr/api-key" = {
+          owner = "radarr";
+        };
+        "nixflix/radarr/password" = {
+          owner = "radarr";
+        };
+
+        "nixflix/prowlarr/api-key" = {
+          owner = "prowlarr";
+        };
+        "nixflix/prowlarr/password" = {
+          owner = "prowlarr";
+        };
+
+        "nixflix/seerr/api-key" = {
+          owner = "seerr";
+        };
+        "nixflix/seerr/jellyfin-admin-password" = {
+          owner = "seerr";
+        };
+
+        "nixflix/jellyfin/users/admin-password" = {
+          owner = "jellyfin";
+        };
+        "nixflix/jellyfin/users/user1-password" = {
+          owner = "jellyfin";
+        };
+        "nixflix/jellyfin/users/user2-password" = {
+          owner = "jellyfin";
+        };
+        "nixflix/jellyfin/api-key" = {
+          owner = "jellyfin";
+        };
+
+        "nixflix/qbittorrent/password" = {
+          owner = "qbittorrent";
+        };
+
+        "nixflix/opensubtitles-com/password" = {
+          owner = "jellyfin";
+        };
+
+        "nixflix/opensubtitles-com/api-key" = {
+          owner = "jellyfin";
+        };
+
+        "nixflix/subdl/api-key" = {
+          owner = "jellyfin";
+        };
+
+        "nixflix/subsource/api-key" = {
+          owner = "jellyfin";
+        };
+      };
+
+      custom.web-expose.routers = {
+        jellyfin = {
+          subdomain = "jellyfin";
+          port = 8096;
+          host = "127.0.0.1";
+          public = true;
+          auth = null;
+        };
+
+        sonarr = {
+          subdomain = "sonarr";
+          port = 8989;
+          host = "127.0.0.1";
+          public = false;
+          auth = null;
+        };
+
+        radarr = {
+          subdomain = "radarr";
+          port = 7878;
+          host = "127.0.0.1";
+          public = false;
+          auth = null;
+        };
+
+        prowlarr = {
+          subdomain = "prowlarr";
+          port = 9696;
+          host = "127.0.0.1";
+          public = false;
+          auth = null;
+        };
+
+        seerr = {
+          subdomain = "seerr";
+          port = 5055;
+          host = "127.0.0.1";
+          public = false;
+          auth = null;
+        };
+
+        qbittorrent-nixflix = {
+          subdomain = "qbittorrent-nixflix";
+          port = 8282;
+          host = "127.0.0.1";
+          public = false;
+          auth = null;
+        };
+      };
+
+      nixflix = {
+        enable = true;
+
+        mediaDir = "/mnt/data/media";
+        downloadsDir = "/mnt/data/downloads";
+        stateDir = "/var/lib";
+        mediaUsers = [username];
+
+        nginx.enable = false;
+        caddy.enable = false;
+
+        postgres.enable = true;
+
+        theme.enable = true;
+
+        sonarr = {
+          enable = true;
+          openFirewall = true;
+
+          config = {
+            apiKey = {
+              _secret = config.sops.secrets."nixflix/sonarr/api-key".path;
+            };
+            hostConfig = {
+              username = "admin";
+              password = {
+                _secret = config.sops.secrets."nixflix/sonarr/password".path;
+              };
+              authenticationMethod = "forms";
+              authenticationRequired = "disabledForLocalAddresses";
+            };
+          };
+        };
+
+        radarr = {
+          enable = true;
+          openFirewall = true;
+
+          config = {
+            apiKey = {
+              _secret = config.sops.secrets."nixflix/radarr/api-key".path;
+            };
+            hostConfig = {
+              username = "admin";
+              password = {
+                _secret = config.sops.secrets."nixflix/radarr/password".path;
+              };
+              authenticationMethod = "forms";
+              authenticationRequired = "disabledForLocalAddresses";
+            };
+          };
+        };
+
+        prowlarr = {
+          enable = true;
+          openFirewall = true;
+
+          config = {
+            apiKey = {
+              _secret = config.sops.secrets."nixflix/prowlarr/api-key".path;
+            };
+            indexers = [
+              {
+                name = "1337x";
+                tags = ["flaresolverr"];
+              }
+              {name = "Nyaa";}
+              {
+                name = "TorrentGalaxy";
+                tags = ["flaresolverr"];
+              }
+              {
+                name = "The Pirate Bay";
+                tags = ["flaresolverr"];
+              }
+              {name = "EZTV";}
+              {name = "LimeTorrents";}
+            ];
+            hostConfig = {
+              username = "admin";
+              password = {
+                _secret = config.sops.secrets."nixflix/prowlarr/password".path;
+              };
+              authenticationMethod = "forms";
+              authenticationRequired = "disabledForLocalAddresses";
+            };
+          };
+        };
+
+        jellyfin = {
+          enable = true;
+          openFirewall = true;
+
+          apiKey = {
+            _secret = config.sops.secrets."nixflix/jellyfin/api-key".path;
+          };
+
+          cacheDir = "/var/cache/jellyfin";
+
+          encoding = {
+            enableHardwareEncoding = true;
+            hardwareAccelerationType = "qsv";
+            qsvDevice = "/dev/dri/renderD128";
+            hardwareDecodingCodecs = [
+              "h264"
+              "hevc"
+              "mpeg2video"
+              "vc1"
+              "vp8"
+              "vp9"
+            ];
+            transcodingTempPath = "/var/cache/jellyfin/transcodes";
+            enableSubtitleExtraction = true;
+            enableIntelLowPowerH264HwEncoder = false;
+            enableIntelLowPowerHevcHwEncoder = false;
+          };
+
+          system = {
+            enableLegacyAuthorization = false;
+            serverName = config.networking.hostName;
+            cacheSize = 4096;
+          };
+
+          libraries = let
+            subtitleSettings = {
+              subtitleFetcherOrder = [
+                "subbuzz"
+                "Open Subtitles"
+              ];
+              subtitleDownloadLanguages = [
+                "eng"
+                "pl"
+              ];
+              saveSubtitlesWithMedia = true;
+              allowEmbeddedSubtitles = "AllowAll";
+              requirePerfectSubtitleMatch = false;
+              skipSubtitlesIfAudioTrackMatches = false;
+              skipSubtitlesIfEmbeddedSubtitlesPresent = true;
+            };
+          in {
+            Shows = subtitleSettings;
+            Movies = subtitleSettings;
+          };
+
+          plugins = {
+            subbuzz = {
+              enable = true;
+              config = {
+                OpenSubUserName = "surface";
+                OpenSubPassword._secret = config.sops.secrets."nixflix/opensubtitles-com/password".path;
+                OpenSubApiKey._secret = config.sops.secrets."nixflix/opensubtitles-com/api-key".path;
+                EnableOpenSubtitles = true;
+                EnableYifySubtitles = true;
+                EnablePodnapisiNet = true;
+                EnableSubSource = true;
+                SubSourceApiKey._secret = config.sops.secrets."nixflix/subsource/api-key".path;
+                EnableSubdlCom = true;
+                SubdlApiKey._secret = config.sops.secrets."nixflix/subdl/api-key".path;
+              };
+            };
+
+            "Open Subtitles" = {
+              enable = true;
+              config = {
+                Username = "surface";
+                Password._secret = config.sops.secrets."nixflix/opensubtitles-com/password".path;
+              };
+            };
+
+            "Subtitle Extract" = {
+              enable = true;
+              config.ExtractionDuringLibraryScan = true;
+            };
+          };
+
+          users = {
+            admin = {
+              password = {
+                _secret = config.sops.secrets."nixflix/jellyfin/users/admin-password".path;
+              };
+              policy = {
+                isAdministrator = true;
+                enableContentDeletion = true;
+                enableSubtitleManagement = true;
+              };
+              configuration = {
+                subtitleMode = "Smart";
+                enableNextEpisodeAutoPlay = true;
+              };
+              mutable = false;
+            };
+            user1 = {
+              password = {
+                _secret = config.sops.secrets."nixflix/jellyfin/users/user1-password".path;
+              };
+              policy = {
+                isAdministrator = false;
+                enableContentDeletion = false;
+                enableSubtitleManagement = false;
+              };
+              configuration = {
+                subtitleMode = "Smart";
+                enableNextEpisodeAutoPlay = true;
+              };
+              mutable = false;
+            };
+            user2 = {
+              password = {
+                _secret = config.sops.secrets."nixflix/jellyfin/users/user2-password".path;
+              };
+              policy = {
+                isAdministrator = false;
+                enableContentDeletion = false;
+                enableSubtitleManagement = false;
+              };
+              configuration = {
+                subtitleMode = "Smart";
+                enableNextEpisodeAutoPlay = true;
+              };
+              mutable = false;
+            };
+          };
+        };
+
+        seerr = {
+          enable = true;
+          openFirewall = true;
+          port = 5055;
+
+          apiKey = {
+            _secret = config.sops.secrets."nixflix/seerr/api-key".path;
+          };
+        };
+
+        torrentClients.qbittorrent = {
+          enable = true;
+          webuiPort = 8282;
+
+          password = {
+            _secret = config.sops.secrets."nixflix/qbittorrent/password".path;
+          };
+        };
+
+        flaresolverr = {
+          enable = true;
+          port = 8191;
+        };
+
+        recyclarr = {
+          enable = true;
+          radarrQuality = "1080p";
+          sonarrQuality = "1080p";
+          cleanupUnmanagedProfiles = {
+            enable = true;
+          };
+        };
+
+        downloadarr = {
+          enable = true;
+        };
+      };
+
+      hardware.graphics = {
+        enable = true;
+        extraPackages = with pkgs; [
+          intel-media-driver
+          intel-vaapi-driver
+          libvdpau-va-gl
+        ];
+      };
+
+      users.users.jellyfin.extraGroups = [
+        "video"
+        "render"
+      ];
+
+      systemd = {
+        mounts = [
+          {
+            what = "tmpfs";
+            where = "/var/cache/jellyfin";
+            type = "tmpfs";
+            options = "size=4G,mode=0755,uid=146,gid=146";
+            before = ["jellyfin.service"];
+            wantedBy = ["multi-user.target"];
+          }
+        ];
+      };
+
+      networking.firewall = {
+        allowedTCPPorts = [6881];
+        allowedUDPPorts = [6881];
+      };
+    };
+  };
+}

--- a/modules/services/nixflix.nix
+++ b/modules/services/nixflix.nix
@@ -5,14 +5,11 @@
 }: {
   flake = {
     nixosModules.nixflix = {
-      lib,
       username,
       config,
       pkgs,
       ...
-    }: let
-      domain = "iameasytoremember.duckdns.org";
-    in {
+    }: {
       imports = [
         inputs.nixflix.nixosModules.default
         self.nixosModules.web-expose

--- a/modules/services/ssh.nix
+++ b/modules/services/ssh.nix
@@ -51,9 +51,6 @@ _: {
       };
 
       home-manager.users.${username} = {pkgs, ...}: {
-        home.packages = with pkgs; [
-          lazyssh
-        ];
         programs.ssh = {
           enable = true;
           enableDefaultConfig = false;
@@ -61,8 +58,17 @@ _: {
             "*" = {
               IdentityFile = "~/.ssh/id_ed25519";
               AddKeysToAgent = "yes";
+              IdentitiesOnly = "yes";
+              ServerAliveInterval = "60";
+              ServerAliveCountMax = "3";
+              ConnectTimeout = "10";
+
+              ForwardX11 = "no";
+              ForwardX11Trusted = "no";
+              PasswordAuthentication = "yes";
+              VisualHostKey = "yes";
             };
-            "Host Server" = {
+            "Iroh" = {
               HostName = "iameasytoremember.duckdns.org";
               User = "nixi";
               Port = 6767;

--- a/modules/services/ssh.nix
+++ b/modules/services/ssh.nix
@@ -50,7 +50,7 @@ _: {
         };
       };
 
-      home-manager.users.${username} = {pkgs, ...}: {
+      home-manager.users.${username} = _: {
         programs.ssh = {
           enable = true;
           enableDefaultConfig = false;

--- a/modules/services/update.nix
+++ b/modules/services/update.nix
@@ -14,17 +14,32 @@ _: {
         automatic = true;
         dates = "weekly";
       };
-      system.autoUpgrade = {
-        enable = true;
-        flake = "github:First-Non-Interesting-Username/NixOS-config#${hostname}";
-        allowReboot = false;
-        persistent = true;
-        dates = "02:00";
-        randomizedDelaySec = "45min";
-        operation = "boot";
-        flags = [
-          "-L"
-        ];
+      systemd = {
+        services.nixos-upgrade = {
+          description = "NixOS upgrade";
+          requires = ["network-online.target"];
+          after = ["network-online.target"];
+
+          serviceConfig = {
+            Type = "oneshot";
+            ExecStart = pkgs.writeShellScript "upgrade" ''
+              set -e
+              ${pkgs.nixos-rebuild}/bin/nixos-rebuild boot \
+                --flake "github:First-Non-Interesting-Username/NixOS-config#$(hostname)" \
+                -L
+            '';
+          };
+        };
+
+        timers.nixos-upgrade = {
+          description = "Run upgrade daily";
+          wantedBy = ["timers.target"];
+          timerConfig = {
+            OnCalendar = "02:00";
+            RandomizedDelaySec = "45min";
+            Persistent = true;
+          };
+        };
       };
     };
   };

--- a/modules/services/update.nix
+++ b/modules/services/update.nix
@@ -25,7 +25,7 @@ _: {
             ExecStart = pkgs.writeShellScript "upgrade" ''
               set -e
               ${pkgs.nixos-rebuild}/bin/nixos-rebuild boot \
-                --flake "github:First-Non-Interesting-Username/NixOS-config#$(hostname)" \
+                --flake "github:First-Non-Interesting-Username/NixOS-config#${hostname}" \
                 -L
             '';
           };

--- a/modules/services/update.nix
+++ b/modules/services/update.nix
@@ -1,6 +1,6 @@
 _: {
   flake = {
-    nixosModules.update = {hostname, ...}: {
+    nixosModules.update = {hostname, pkgs,...}: {
       programs.nh = {
         enable = true;
         clean = {

--- a/modules/system/impermanence.nix
+++ b/modules/system/impermanence.nix
@@ -39,6 +39,7 @@
           users.${username} = {
             directories = [
               ".cache/mesa_shader_cache"
+              "persist"
             ];
 
             files = [
@@ -60,7 +61,7 @@
         home-manager.users.${username} = _: {
           programs.zsh.initContent = ''
             if [[ $PWD == $HOME ]]; then
-                cd ~/Persist
+                cd ~/persist
             fi
           '';
         };

--- a/modules/system/networking.nix
+++ b/modules/system/networking.nix
@@ -17,7 +17,6 @@ _: {
 
         nameservers = ["1.1.1.1" "1.0.0.1"];
 
-
         useDHCP = false;
 
         firewall = {

--- a/modules/system/networking.nix
+++ b/modules/system/networking.nix
@@ -140,7 +140,7 @@ _: {
         hostName = hostname;
         networkmanager.enable = false;
 
-        interfaces.eno1 = {
+        interfaces.enp1s0 = {
           useDHCP = false;
           ipv4.addresses = [
             {

--- a/modules/system/networking.nix
+++ b/modules/system/networking.nix
@@ -12,7 +12,7 @@ _: {
         hostName = hostname;
         networkmanager = {
           enable = true;
-          dns = false;
+          dns = "none";
         };
 
         nameservers = ["1.1.1.1" "1.0.0.1"];
@@ -103,11 +103,12 @@ _: {
       impermanence,
       ...
     }: {
+
       networking = {
         hostName = hostname;
         networkmanager = {
           enable = true;
-          dns = false;
+          dns = "none";
         };
 
         nameservers = ["1.1.1.1" "1.0.0.1"];

--- a/modules/system/networking.nix
+++ b/modules/system/networking.nix
@@ -129,7 +129,7 @@ _: {
         hostName = hostname;
         networkmanager.enable = false;
 
-        interfaces.ens18 = {
+        interfaces.eno1 = {
           useDHCP = false;
           ipv4.addresses = [
             {

--- a/modules/system/networking.nix
+++ b/modules/system/networking.nix
@@ -10,7 +10,13 @@ _: {
       sops.secrets."wifi_password" = {};
       networking = {
         hostName = hostname;
-        networkmanager.enable = true;
+        networkmanager = {
+          enable = true;
+          dns = false;
+        };
+
+        nameservers = ["1.1.1.1" "1.0.0.1"];
+
 
         useDHCP = false;
 
@@ -100,7 +106,12 @@ _: {
     }: {
       networking = {
         hostName = hostname;
-        networkmanager.enable = true;
+        networkmanager = {
+          enable = true;
+          dns = false;
+        };
+
+        nameservers = ["1.1.1.1" "1.0.0.1"];
 
         useDHCP = false;
 
@@ -133,14 +144,14 @@ _: {
           useDHCP = false;
           ipv4.addresses = [
             {
-              address = "192.168.0.124";
+              address = "192.168.0.10";
               prefixLength = 24;
             }
           ];
         };
 
         defaultGateway = "192.168.0.1";
-        nameservers = ["192.168.0.1"];
+        nameservers = ["1.1.1.1" "1.0.0.1"];
 
         firewall = {
           enable = true;

--- a/renovate.json
+++ b/renovate.json
@@ -28,8 +28,11 @@
 
   "packageRules": [
     {
-      "matchUpdateTypes": ["minor", "patch", "digest"],
-      "matchCurrentVersion": "!/^v?0\\./",
+      "matchDatasources": ["docker"],
+      "automerge": true
+    },
+    {
+      "matchDatasources": ["github-actions"],
       "automerge": false
     }
   ]

--- a/secrets/secrets.yaml
+++ b/secrets/secrets.yaml
@@ -98,10 +98,11 @@ headplane:
     oidc-client-secret-hash: ENC[AES256_GCM,data:AbU4YE6K0FS951RkPzt68VYeEn+EXllOHP2AK3nI+5pJins7tvaqjkOfVfWE14RBGNZzvXJ4ZMrqJKqCCrkP9w2y89cICV073sq0zQb2+MwxJiWS7yugDksEmIduhjCD2Q==,iv:HCJ/QhuiJynrqP/9SBe5nBxZWvkSkoyJ3zMLbyun66w=,tag:4318Ps3GLfzhWwDroPgUWw==,type:str]
 headscale:
     api-key: ENC[AES256_GCM,data:rrEHxe7NNho7PonCQKiGXMp13qM2rZXJCmWC7232NTjCoFOg0E9vwN0=,iv:rS/05i49LscY6iL1rtRHYi4Q8KRDjA/ny311eIv+rcE=,tag:RUISUG8ux//nPd+r/Xcq1g==,type:str]
+fgc:
+    env: ENC[AES256_GCM,data:0Q5QbyHGH588jdzv2qsBy4RgzdhxfKoc0nUIxQ9mgD7MWuUD4uy/EaSGfmutzBjgVBHiaoAioWPf4JAO6m41Q9hXZSs1DWcaztUPQ0QXPHtYPamXuOzw1IB4MtEp5/jeByEwiCFOOD0ExKY5z5y64ChDn/6FESewltItRiDLYfQC0LH4BlhTNURoqAGs4limUaexJkwz+Jvwjx1ERsWQfuA2J4vRaAqa2xayJZseAC49tknRhnCq1/JHhHkYOvCCPrpgmLUajLhmCYxsctiSYXY9lOeWM8DPDjl4hpGEat0yOgLs2G5cDfiUl0Gr9KYl2IW0B9Bx5CaRzESyThZxD8CHkGaBjt4/4CP0k7ixbxNAIkSRln52qo+SNMzN6i+XoEj3jGQ9Ko4+TlZUN5vmj4k//oj7aXYCfc67qYRUzdtTdjljOTpG7/payL1T7o4YwigMoodkE+fApHUZ1n2CvMJEFX1q1TuQjxoI+zHbOoCfIeQqUmtdpjQW6+MGgrBJYLvRmpcTCrci+8Y3eWufe24eX+4XB2O8JGpU6fqTrHjvEaOicAoG7L7FUvTtBtwR2YO5wp50p7a2MkeGOZnx4FI/IALR7oSP4Jqpo4qj05cKp9+EtEODjwIXovjUgEeIqFZijg7MthNTR2F1LP22zK+ODqHrcUiCedF6J5WJk0pf29z15R8HMcwQqonaps3nG+LB0sD41X+UjEzjyFFtIa9n7pE=,iv:ZEwn7A7BiX02EzsumD+lnDbAX3KdQg67ip00P7Wu8SY=,tag:mBmHzw/PO4yZ5AhnbMnUOA==,type:str]
 sops:
     age:
-        - recipient: age18nl2k827fm6esp56a7vadd2lln3uww2j9vaaa2ads7z2zntppecqnpe92j
-          enc: |
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBOdHVZTHgzVW83NlZJQXA0
             cUd0ZlQ0SVZjVEZyamtpR0hFTFFNd2dwNm5jClhpQURLRWEyUlhQcG4rUGREQ0xu
@@ -109,8 +110,8 @@ sops:
             b0dyQU92YnZvMlRLYXo1YjRxeWwydTgKh3PXCvywMHQttegawnuTH3ShGCMMukYB
             /gXxni0nLD93U+cp6kWRZCNm+jzWWrohhC/v2u1SMju10X0iXsFSXw==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1lxeguqlvkd75um6yd2hsum269p2zly6g7tgdeqxm602ujjurjyvqe9g24u
-          enc: |
+          recipient: age18nl2k827fm6esp56a7vadd2lln3uww2j9vaaa2ads7z2zntppecqnpe92j
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBwNmxxZ0V5bnd1cG4xdytq
             SE1sK0dVSG4xRUtFUUZIdndEWnJmNDFEc1gwCjQ2Z2Jqa2gzNy9LQ1dDaUJ6SVdI
@@ -118,8 +119,8 @@ sops:
             NWZ2WGVhRGVqM205QkE1RjV6aXVBRTAK5pEwSZegLhbCOelk7/Nyd8aIOrWLqoku
             vMOX98fksUkT4XEiFs+mvygziezMNlLAtap8QQ9slRNWuG1M/q3UcQ==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age1x6pwl6gwnrfmnjzu2kk9ave86tx9jur5yh870jzw94f8km7nm93shgfmqa
-          enc: |
+          recipient: age1lxeguqlvkd75um6yd2hsum269p2zly6g7tgdeqxm602ujjurjyvqe9g24u
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBwWml4aUtwUnhkc01iaFU4
             YnNiYXlwNnI2WFNjUnZxQUpYYVdJc0V1L1RrCnJ0aGZqYlgvYlBXYUFMTmZoT0xQ
@@ -127,8 +128,8 @@ sops:
             K3pmZUxSc0tWVi9XcUtWVEVEc1dmTVUKieelngU1K5ttbH2k8amN6IZWOvmtGwOu
             NKWi+yBrromog6UfrwMC5XawHDNdtRi7NkTz72mLNmXYql9AZBmasA==
             -----END AGE ENCRYPTED FILE-----
-        - recipient: age15tmwsj524vlg5ppfx66zqf2jux5zk3sdw50jv708v7qzfr3vsq8q6f2ta3
-          enc: |
+          recipient: age1x6pwl6gwnrfmnjzu2kk9ave86tx9jur5yh870jzw94f8km7nm93shgfmqa
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWT293M1ZjclZadldPVGww
             WTBXMGhNRTc1VTAyZGV3cVVEZ2dZL0JMbzA0CklONzBRNmJ1WGlSTmVGNVBrVUpX
@@ -136,7 +137,8 @@ sops:
             bi9JMnk5c2pzaVAxb2YvdFc3ZHV1UkEKIMWW8nmSIrzwVThx/DVYDe9j/w7jhkK+
             2YlFY68Kv9k7t9oba8fte6Ku+IL5TT22PLs4/QT6PjGcUKDZGDVvqg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-25T16:24:41Z"
-    mac: ENC[AES256_GCM,data:0yuAbn90xEBIl39rYwmNGFqvVwLuIDIobxwcvAkGGhod/inyTammmNwK8A1IjM/RHdpSxAYwv3Dr8L22QxGF8HeR+HEHkTbMSPjNO91vbiztN1p27xJttSQvL9Ill/Zomalefu3AHqX5Ar042g+WTsIhBtCUrQ1gfYlib76PVcU=,iv:/FOXmzly4kGQlrmruREYbl9CDnkYyMA+5sbDeFDStYg=,tag:PG7rYZ7BJZzFmORqIlW11Q==,type:str]
+          recipient: age15tmwsj524vlg5ppfx66zqf2jux5zk3sdw50jv708v7qzfr3vsq8q6f2ta3
+    lastmodified: "2026-06-14T10:36:02Z"
+    mac: ENC[AES256_GCM,data:qv2BXrIqfwQeA8HRfDDRmgNfU3qdQRUgGoOad61o+b2CkiWlDvCEWRo1jQXm2bdIWPRFUU0G9CBluSFtdw/vLQLqlR7gTBY5/XB0q+XGWP8WyH/4yQH6y4HbDsyZBoddDQW3jlta7XmtXaZKyOW0ioDBB9vZbXo61BGtB8Sptx8=,iv:0Z/r001T843CYvZguwkroZXhyFPHrT9jKMK14eFky/g=,tag:Y6CYUt3FjNI3iLxe838qvA==,type:str]
     unencrypted_suffix: _unencrypted
-    version: 3.12.2
+    version: 3.13.1

--- a/secrets/secrets.yaml
+++ b/secrets/secrets.yaml
@@ -99,7 +99,9 @@ headplane:
 headscale:
     api-key: ENC[AES256_GCM,data:rrEHxe7NNho7PonCQKiGXMp13qM2rZXJCmWC7232NTjCoFOg0E9vwN0=,iv:rS/05i49LscY6iL1rtRHYi4Q8KRDjA/ny311eIv+rcE=,tag:RUISUG8ux//nPd+r/Xcq1g==,type:str]
 fgc:
-    env: ENC[AES256_GCM,data:0Q5QbyHGH588jdzv2qsBy4RgzdhxfKoc0nUIxQ9mgD7MWuUD4uy/EaSGfmutzBjgVBHiaoAioWPf4JAO6m41Q9hXZSs1DWcaztUPQ0QXPHtYPamXuOzw1IB4MtEp5/jeByEwiCFOOD0ExKY5z5y64ChDn/6FESewltItRiDLYfQC0LH4BlhTNURoqAGs4limUaexJkwz+Jvwjx1ERsWQfuA2J4vRaAqa2xayJZseAC49tknRhnCq1/JHhHkYOvCCPrpgmLUajLhmCYxsctiSYXY9lOeWM8DPDjl4hpGEat0yOgLs2G5cDfiUl0Gr9KYl2IW0B9Bx5CaRzESyThZxD8CHkGaBjt4/4CP0k7ixbxNAIkSRln52qo+SNMzN6i+XoEj3jGQ9Ko4+TlZUN5vmj4k//oj7aXYCfc67qYRUzdtTdjljOTpG7/payL1T7o4YwigMoodkE+fApHUZ1n2CvMJEFX1q1TuQjxoI+zHbOoCfIeQqUmtdpjQW6+MGgrBJYLvRmpcTCrci+8Y3eWufe24eX+4XB2O8JGpU6fqTrHjvEaOicAoG7L7FUvTtBtwR2YO5wp50p7a2MkeGOZnx4FI/IALR7oSP4Jqpo4qj05cKp9+EtEODjwIXovjUgEeIqFZijg7MthNTR2F1LP22zK+ODqHrcUiCedF6J5WJk0pf29z15R8HMcwQqonaps3nG+LB0sD41X+UjEzjyFFtIa9n7pE=,iv:ZEwn7A7BiX02EzsumD+lnDbAX3KdQg67ip00P7Wu8SY=,tag:mBmHzw/PO4yZ5AhnbMnUOA==,type:str]
+    env: ENC[AES256_GCM,data:f+a1OZFmS4NH0eOSN9PQdBw2geE4eaW7KIm8vibNlPppgkLC41QB7N5G9bKy95tF7pXGm2Kj5Kc8Cr5k5gnHqmtU064Ogbi3bB41vDCdia2E4/kRwkBe6bvTnSddLeD9cAWOoSW2hf22O2MO9cAGtV0pgU6xWkMZeWnevEhi52FKBQBSWLHwODmQoQ1k6+0wnv0UewZ+pzem54oHtKso9+y9zXTpkKtLqPJ87uscC7IOmU8EF0j31hvbMB5x7zWJiqql00KTINCfFUE3HfypGBuAOYNR7KlWVjuCVLd4DKuiZUeVU2SOwNIxiEO1rR3oNYnbREhb00pUCi/liCjTomj45/UyflqHjTfqqY4g2bazZHbX2Obety7gyBGJoXm2D4vnQi1X7VQlGLs/xFyIwgrGQQfPYwOuPirqrUVvaOwUlTN5eExah9O7cMSarAmI0ZZfdvaqaUJOmyxaI0ejy+8dhtz6KRy0SfbmLr9IuPt+dP22X+Tv6ksF5vflRCDF/jTg+6bNdaaNaZbEKX82CONWuT9pFm09+YibuZq4bNYYN+Ax9OK+rmPDgJcp0ybvTuRhqYH4DrlMRefsY8InTitmAiBffccvZfrhXn8jQsGCkh7xT9dzbJNnNaayQSvqGGLefO+u2ceWUzvucGmTXPRY7ES4dXZixprHDYdtEbG8AUyg0B9g0esUPXObvbiPRkd4UhsTY4WDv0AwqErjXCcA7Xc=,iv:ozMMHcMVgUXAz6KlsEFOqX+19kWqZI/lnRA8QCHC1iY=,tag:/zJCVPxZY5HfHhD6YoXQ7w==,type:str]
+aiostreams:
+    env: ENC[AES256_GCM,data:qS90Z01R4jlBydZEue+xAiQ3ZIPfJQAZXWx4fuZaXG51106CbLdfNDdf2V5FJ811onAg5Du4RfsFmMbV0QSePRrVehV+mGv9YCdFSz00thHKw0Qgez9f1dyEUZzJ3c/5w0zr5WAX/+LtMnkjzcnLISt9iVD94bkP8yJq3IEApRzmpQ==,iv:d8IeUUn7SvXP5dnHM+wjj3M4sAKkRMD3ahYpzjbZqLU=,tag:bqaqVtVCmaKZ5eoG+nkwRA==,type:str]
 sops:
     age:
         - enc: |
@@ -138,7 +140,7 @@ sops:
             2YlFY68Kv9k7t9oba8fte6Ku+IL5TT22PLs4/QT6PjGcUKDZGDVvqg==
             -----END AGE ENCRYPTED FILE-----
           recipient: age15tmwsj524vlg5ppfx66zqf2jux5zk3sdw50jv708v7qzfr3vsq8q6f2ta3
-    lastmodified: "2026-06-14T10:36:02Z"
-    mac: ENC[AES256_GCM,data:qv2BXrIqfwQeA8HRfDDRmgNfU3qdQRUgGoOad61o+b2CkiWlDvCEWRo1jQXm2bdIWPRFUU0G9CBluSFtdw/vLQLqlR7gTBY5/XB0q+XGWP8WyH/4yQH6y4HbDsyZBoddDQW3jlta7XmtXaZKyOW0ioDBB9vZbXo61BGtB8Sptx8=,iv:0Z/r001T843CYvZguwkroZXhyFPHrT9jKMK14eFky/g=,tag:Y6CYUt3FjNI3iLxe838qvA==,type:str]
+    lastmodified: "2026-06-14T13:04:36Z"
+    mac: ENC[AES256_GCM,data:1KZzxSJvHjTwGpqOW4/8mCFHiICLPtA7Y3hSniSUwqxgdWHZEH5wDUnFOqQmMlmhwEEOlSjP+4k8jT4SIN4yxLvwANeOxXszBxe70xPjvS3MAkmqtkQ2ZCkc6p8AX4oLz7THgvLYEDE6oW49LLhAW7BxDpkUtiO7hzeWd/rYGhI=,iv:D/4gJkCvmAubjpZ9lSEZaVWhj0Ah9lWiJIpBq/u5GiU=,tag:Sny7qoiPmAYMszScx0c44Q==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.1


### PR DESCRIPTION
## Description

The iroh host was changed from being run in a VM to bare metal, along with a few improvements.

## Motivation

I did not need proxmox

## Changes

- Add free games claimer
- move nixflix to a separate file, disable it
- add aiostreams
- improve hardware configuration for iroh
- add nas module
- use custom upgrade solution

## Checklist

- [x] Code follows the style guidelines.
- [x] `nix flake check` passes.
- [x] Documentation is updated if needed.
- [x] Commit messages follow Conventional Commits.
- [x] You added yourself to [CONTRIBUTORS.md](./CONTRIBUTORS.md) (optional).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NAS server/client support for network storage configuration, including optional persistence.
  * Introduced new streaming apps and container setup (FGC and Aiostreams) with updated reverse-proxy routing.
  * Expanded SSH client configuration options.
* **Bug Fixes**
  * Improved system reliability with more stable disk device identification and updated storage-focused hardware/init settings.
* **Documentation**
  * Updated host specifications and service module documentation.
* **Chores**
  * Improved CI build workflow for ARM runners; updated merge-message parsing; refreshed system/network defaults, state versions, and tightened firewall ports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->