### PR TITLE
Add 'nofail' option to mountOptions in disko.nix

### DIFF
--- a/hosts/iroh/disko.nix
+++ b/hosts/iroh/disko.nix
@@ -85,7 +85,7 @@ _: {
                 format = "xfs";
                 extraArgs = ["-d" "su=64k,sw=1" "-l" "size=256m,lazy-count=1"];
                 mountpoint = "/mnt/storage";
-                mountOptions = ["noatime" "largeio" "inode64" "noquota" "allocsize=64m"];
+                mountOptions = ["noatime" "largeio" "inode64" "noquota" "allocsize=64m" "nofail"];
               };
             };
           };


### PR DESCRIPTION
## Description

<!-- What does this change do? -->

## Motivation

<!-- Why is this change needed? -->

## Changes

- <!-- List the changes made -->

## Fixes

- fixes #123
- fixes #234

## Checklist

- [ ] Code follows the style guidelines.
- [ ] `nix flake check` passes.
- [ ] Documentation is updated if needed.
- [ ] Commit messages follow Conventional Commits.
- [ ] You added yourself to [CONTRIBUTORS.md](./CONTRIBUTORS.md) (optional).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated storage partition mount configuration to allow the system to boot successfully even if the storage drive is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->