### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,8 @@ on:
 jobs:
   check:
     uses: ./.github/workflows/flake-check.yaml
+    permissions:
+      contents: read
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/First-Non-Interesting-Username/NixOS-config/security/code-scanning/16](https://github.com/First-Non-Interesting-Username/NixOS-config/security/code-scanning/16)

Add an explicit `permissions` block to the `check` job in `.github/workflows/release.yaml`, directly under the reusable workflow `uses` entry (same job scope).  
For a minimal safe baseline that does not grant write access, set:

- `contents: read`

This preserves functionality for typical checkout/read operations while explicitly constraining `GITHUB_TOKEN`. No imports, methods, or dependencies are needed since this is YAML workflow configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
