### PR TITLE
fix: disable vicinae

### DIFF
--- a/desktop-environment/GNOME/default.nix
+++ b/desktop-environment/GNOME/default.nix
@@ -7,7 +7,7 @@
       ...
     }: {
       imports = [
-        self.nixosModules.vicinae
+        # self.nixosModules.vicinae
         self.nixosModules.wayland
       ];
 


### PR DESCRIPTION
## Description

<!-- What does this change do? -->

## Motivation

<!-- Why is this change needed? -->

## Changes

- <!-- List the changes made -->

## Fixes

- fixes #123
- fixes #234

## Checklist

- [ ] Code follows the style guidelines.
- [ ] `nix flake check` passes.
- [ ] Documentation is updated if needed.
- [ ] Commit messages follow Conventional Commits.
- [ ] You added yourself to [CONTRIBUTORS.md](./CONTRIBUTORS.md) (optional).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the GNOME desktop setup so it no longer includes an extra integration component by default.
  * This may help avoid unwanted behavior or conflicts in GNOME environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->