### PR TITLE
Remove git commit shell alias from git.nix

### DIFF
--- a/modules/configuration/development/git.nix
+++ b/modules/configuration/development/git.nix
@@ -67,10 +67,6 @@ _: {
             $env.GH_TOKEN = (open ${osConfig.sops.secrets.github_pat.path} | str trim)
           '';
         };
-
-        home.shellAliases = {
-          commit = "git add . && git commit -m";
-        };
       };
     };
     nixosModules.secretless-git = {


### PR DESCRIPTION
Removed shell alias for git commit in development configuration.

## Description

 <!-- What does this change do? 

 ## Motivation

 Why is this change needed? 

## Changes

- List the changes made -->

<!-- ## Fixes

-  fixes #123
- fixes #234 -->

## Checklist

- [ ] Code follows the style guidelines.
- [ ] `nix flake check` passes.
- [ ] Documentation is updated if needed.
- [ ] Commit messages follow Conventional Commits.
- [ ] You added yourself to [CONTRIBUTORS.md](./CONTRIBUTORS.md) (optional).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub authentication is now automatically available in NuShell through a token loaded from the existing secret store.
* **Bug Fixes**
  * Removed a shell commit shortcut that is no longer provided in the development setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->